### PR TITLE
Fixes to meshless scheme (for block timesteps), usergiude and other small changes

### DIFF
--- a/docs/userguide.tex
+++ b/docs/userguide.tex
@@ -1626,15 +1626,15 @@ The \var{Simulation} class is the class that contains every other class, includi
 \item \var{AlgorithmSimulation} - Child class containing specific algorithmic implementation.  For example, `grad-h' SPH simulations are run by the \var{GradhSphSimulation} class; pure N-body simulations are run by the \var{NbodySimulation} class, etc..
 \end{itemize}
 
-\subsubsection{Sph class}
+\subsubsection{Hydrodynamics class}
 
-\subsubsection{SphKernel class}
+\subsubsection{SmoothingKernel class}
 
-\subsubsection{SphIntegration class}
-
-\subsubsection{SphNeighbourSearch class}
+\subsubsection{NeighbourSearch class}
 
 \subsubsection{EOS class}
+
+\subsubsection{EnergyEquation class}
 
 \subsubsection{Nbody class}
 
@@ -1651,7 +1651,7 @@ The simplest case of using templates in GANDALF is for dimensionality.  For almo
 Throughout the code, the variables that are used as template parameters are :
 \begin{itemize}
 \item \var{ndim} : Number of dimensions
-\item \var{SphKernel} : SPH kernel function used
+\item \var{Kernel} : Smoothing kernel function used
 \item \var{ParticleType} : Particle data structure for employed hydrodynamics method
 \item \var{CellType} : Radiation transport tree cell-type, depending on employed RT method
 \end{itemize}
@@ -1674,6 +1674,90 @@ The various particle data structures are defined in the header file \var{`SphPar
 If a class which does not know the exact particle data structure wishes to access an array, or a single array element.
 
 
+\newpage
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\section{Units and scaling}
+In GANDALF, all physical calculations are done in dimensionless units for precision and accuracy reasons.  However, the scaling factors for converting the initial conditions and parameters (in physical units) are calculated automatically, once the user has specified the units of the quantities in the parameters file.
+
+
+\subsection{Calculating scaling factors}
+Most physical quantities in GANDALF are some combination of the three basic physical unit types, length, mass and time.  In principle, we are free to choose any scaling factor in order to convert to dimensionless units
+\begin{equation}
+r' = \frac{r}{R_0} \;\;\;\;\;\;\;\;
+m' = \frac{m}{M_0} \;\;\;\;\;\;\;\;
+t' = \frac{t}{T_0}
+\end{equation}
+where $r, m, t$ are the physical quantities, $r', m', t'$ are the dimensionless analogues and $R_0, M_0, T_0$ are the scaling factors.  The internal scaling factors for most quantities is some combination of the scaling factors of these three basic quantities.  For example, the scaling factor for the dimensionless velocity, $v' = v/V_0$ is equal to $V_0 = R_0/T_0$.
+
+
+\subsection{Scaling factors for \var{G=1}}
+If we take some equation using \var{G} (e.g. Newton's law of gravity) and then substitute in the scaling factors and rearrange, we obtain : 
+\begin{eqnarray}
+a = \frac{G\,m}{r^2} \;\;\;\; \Rightarrow \;\;\;\;
+\frac{R_0}{T_0^2}\,a' = \frac{G\,M_0\,m'}{{r'}^2\,R_0^2} \;\;\;\; \Rightarrow \;\;\;\; a' = \underbrace{\left\{\frac{G\,M_0\,T_0^2}{R_0^3} \right\}}_{G'}\,\frac{m'}{{r'}^2}\,.
+\end{eqnarray}
+The final dimensionless equation has the same form as the original equation, with all constants and scaling factors grouped together in the `dimensionless gravitational constant', \var{G'}.  In N-body codes, it is common to adjust one of the scaling factors in order to set this new constant equal to unity.  By convention, it is the time scaling factor that is adjusted : 
+\begin{eqnarray}
+\frac{G\,M_0\,T_0^2}{R_0^3} = 1 \;\;\;\; \Rightarrow \;\;\;\;T_0 = \left( \frac{R_0^3}{G\,M_0} \right)^{1/2}
+\end{eqnarray}
+For example, typical N-body units (at least in star cluser/formation simulations) of $R_0 = 1\,{\rm pc}$ and $M_0 = 1\,{\rm M}_{\odot}$ give a time scaling factor of $T_0 = 14.91\,{\rm Myr}$.  It is important to realise that this then has a knock-on effect on any other physical quantity that contains the dimensions of time.  For example, the unit of velocity becomes $V_0 = R_0/T_0 = 0.065\,{\rm km\,s^{-1}}$.
+
+
+\subsection{Temperature scaling factor}
+In thermodynamics, one additional unit that is often used (more often in the output rather than in internal quantities) is the thermodynamic temperature.  This quantity represents an additional unit that cannot be represented in any combination of length, mass and time.  The conversion between the three principle quantities is achieved via the Boltzmann constant.  Just as with setting $G = 1$, we can also combine and convert quantities involving temperature to an appropriate dimensionless unit, $T' = T/\theta_0$, by effectively setting the quantity $k_b/m_h$ equal to unity, i.e.
+\begin{equation}
+c^2 = \gamma \frac{k_b\,T}{\bar{m}} \;\;\;\; \Rightarrow \;\;\;\;
+V_0^2\,{c'}^2 = \gamma\,\frac{k_b\,\theta_0\,T'}{m_h\,\bar{\mu}}
+\;\;\;\; \Rightarrow \;\;\;\;
+{c'}^2 = \gamma \; \underbrace{ \left\{ \frac{k_b\,\theta_0}{m_h\, V_0^2} \right\} }_{1} \; \frac{T'}{\bar{\mu}}
+\end{equation}
+\begin{equation}
+\frac{k_b\,\theta_0}{m_h\, V_0^2} = 1 \;\;\;\; \Rightarrow \;\;\;\; \theta_0 = V_0^2\,\frac{m_h}{k_b}
+\end{equation}
+
+
+
+
+\subsection{Computing scaling variables in GANDALF}
+For consistency, GANDALF computes all scaling variables internally in SI units.  However, this is not useful for astrophysical applications where the natural units to choose may be parsecs or megayears.  Therefore, the internal scaling variables are split into two parts for convenience in chosing an appropriate.  For a given unit \var{X}, the scaling factor is split into $X_0 = X_{\rm outscale} \, X_{\rm outSI}$, where
+\begin{itemize}
+\item $X_{\rm outscale}$ : scale factor to convert $X'$ to $X$ in the user-requested units;
+\item $X_{\rm outSI}$ : the requested unit in SI units.
+\end{itemize}
+To convert from the code units to the user-requested units, $X_{\rm user} = X_{\rm outscale}\,X'$.  Alternatively, if you wish to convert directly to SI units, then you must also multiply by $X_{\rm outSI}$, i.e. $X_{\rm user} = X_{\rm outscale}\,X_{\rm outSI}\,X'$.  One alternative possibility is if the user wishes to convert from code units to c.g.s. units; in which case, they must use $X_{\rm outcgs}$ in place of $X_{\rm outSI}$, i.e. $X_{\rm user} = X_{\rm outscale}\,X_{\rm outcgs}\,X'$
+
+\subsection{Converting initial conditions to code units}
+Converting from physical units to code units (e.g. when setting up initial conditions) is trivial once the scaling factors have been computed.  Assuming the initial conditions for all variables are in the same units as specified in the parameters file, then we must simply divide by the $X_{\rm outscale}$, i.e.
+\begin{equation}
+X' = \frac{X_{\rm user}}{X_{\rm outscale}}\,.
+\end{equation}
+If the variable (or parameter) is in either SI or cgs units, then they can be converted directly also using the SI or cgs scaling factors.  For example, to convert a cgs quantity to code units, 
+\begin{equation}
+X' = \frac{X_{\rm user}}{X_{\rm outscale}\,X_{\rm outcgs}}\,.
+\end{equation}
+
+Inside the code, each unit is its own separate class defined in the src/Headers/SimUnits.h and src/Common/SimUnits.cpp files.  All units are then stored in a single container class, called `SimUnits'.  This is then passed around the simulation as an object with the name \var{simunits}.  The object name for each individual unit itself is usually a single character (e.g. \var{r} for length, \var{m} for mass, \var{t} for time, etc..  See the src/Headers/SimUnits.h files for a full list).  For example, the following line could be used to convert the particle mass from physical (user) units to code units,  \\
+\newline
+\noindent \var{part.m /= simunits.m.outscale;} \\
+
+\noindent For converting from say cgs units to code units, we could write \\
+\newline
+\noindent \var{part.m /= (simunits.m.outscale*simunits.m.outcgs);} \\
+
+
+
+
+
+\subsection{Input and output units}
+GANDALF does support the ability to read in initial conditions in a different set of units to use specified in the parameters file.  At the moment, this is only implemented in the \var{sf/seren\_formatted} and \var{su/seren\_unformatted}.  In practice, this is implemented by noting that the input and output scaling factors should be exacty the same, i.e.
+\begin{equation}
+X_0 = X_{\rm outscale} \, X_{\rm outSI} = X_{\rm inscale} \, X_{\rm inSI}
+\end{equation}
+
+
+
 
 \newpage
 
@@ -1685,7 +1769,7 @@ If a class which does not know the exact particle data structure wishes to acces
 List of known bugs as of version \VERNO.
 
 \begin{itemize}
-\item Godunov SPH and Saitoh \& Makino (2012) SPH have not been fully updated since recent code refactoring.
+\item Saitoh \& Makino (2012) SPH has not been fully updated since recent code refactoring.
 \item For very short simulations, plots may not be updated correctly since the simulation process finishes before the plotting process has recieved its commands.
 \item If running a simulation in interactive mode and a different simulation is loaded into memory, then it is no longer possible to continue running that simulation.
 \item Rendered images are technically not done correct if smoothing lengths are smaller than the grid size (which can often be the case, although the images are fine for viewing/movie purposes).
@@ -1704,7 +1788,6 @@ List of possible new features for future versions.
 \item Include analysis routines for python for N-body specific statistics, e.g. Q-parameter, $\lambda$-parameter, etc..
 \item Strict energy-error checking for N-body simulations
 \item More sanity-checking, error-trapping and assert statements (to prevent crashing on erroneous input and to help debugging purposes).
-\item Update Godunov SPH to 2nd-order using slope limiters.
 \end{itemize}
 
 

--- a/src/Common/IC.cpp
+++ b/src/Common/IC.cpp
@@ -423,6 +423,7 @@ void Ic<ndim>::ShockTube(void)
         for (k=0; k<ndim; k++) part.r[k] = r[ndim*i + k];
         for (k=0; k<ndim; k++) part.v[k] = (FLOAT) 0.0;
         part.v[0] = vfluid1[0];
+        part.rho = rhofluid1;
         part.m = rhofluid1*volume/(FLOAT) Nbox1;
         part.h = hydro->h_fac*pow(part.m/rhofluid1,invndim);
         if (hydro->gas_eos == "isothermal") part.u = temp0/gammaone/mu_bar;
@@ -440,6 +441,7 @@ void Ic<ndim>::ShockTube(void)
         Particle<ndim>& part = hydro->GetParticlePointer(i);
         for (k=0; k<ndim; k++) part.r[k] = r[ndim*j + k];
         for (k=0; k<ndim; k++) part.v[k] = (FLOAT) 0.0;
+        part.rho = rhofluid2;
         part.v[0] = vfluid2[0];
         part.m = rhofluid2*volume/(FLOAT) Nbox2;
         part.h = hydro->h_fac*pow(part.m/rhofluid2,invndim);

--- a/src/Headers/EOS.h
+++ b/src/Headers/EOS.h
@@ -47,6 +47,10 @@ template <int ndim>
 class EOS;
 
 
+enum eosenum{noeos, isothermal, barotropic, barotropic2, energy_eqn,
+             constant_temp, radws, Nhydroeos};
+
+
 
 //=================================================================================================
 //  Class EOS

--- a/src/Headers/ExternalPotential.h
+++ b/src/Headers/ExternalPotential.h
@@ -78,7 +78,7 @@ class NullPotential : public ExternalPotential<ndim>
 //=================================================================================================
 //  Class VerticalPotential
 /// \brief   Add simple constant gravitational field potential
-/// \details ...
+/// \details Add simple constant gravitational field potential
 /// \author  D. A. Hubber
 /// \date    14/03/2015
 //=================================================================================================
@@ -91,17 +91,17 @@ class VerticalPotential : public ExternalPotential<ndim>
     kgrav(_kgrav), avert(_avert), rzero(_rzero) {}
   ~VerticalPotential();
 
-  const int kgrav;                     ///< ..
-  const FLOAT avert;                  ///< ..
-  const FLOAT rzero;                  ///< ..
+  const int kgrav;                     ///< 'Direction' of grav. field
+  const FLOAT avert;                   ///< Size (plus sign) of grav. field
+  const FLOAT rzero;                   ///< 'Zero' -height of potential
 
 
   void AddExternalPotential
-   (FLOAT rp[ndim],                   ///< Position of particle
-    FLOAT vp[ndim],                   ///< Velocity of particle
-    FLOAT ap[ndim],                   ///< Acceleration of particle
-    FLOAT adotp[ndim],                ///< 'Jerk' of particle
-    FLOAT &potp)                      ///< Potential of particle
+   (FLOAT rp[ndim],                    ///< Position of particle
+    FLOAT vp[ndim],                    ///< Velocity of particle
+    FLOAT ap[ndim],                    ///< Acceleration of particle
+    FLOAT adotp[ndim],                 ///< 'Jerk' of particle
+    FLOAT &potp)                       ///< Potential of particle
   {
     ap[kgrav]    += avert;
     adotp[kgrav] += (FLOAT) 0.0;

--- a/src/Headers/Particle.h
+++ b/src/Headers/Particle.h
@@ -41,10 +41,6 @@ enum ptype{gas, icm, boundary, cdm, dust, dead,
            Nhydrotypes};
 
 
-enum eosenum{noeos, isothermal, barotropic, barotropic2, energy_eqn,
-             constant_temp, radws, Nhydroeos};
-
-
 typedef bool Typemask[Nhydrotypes];
 
 //static Typemask truemask = {true};

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -195,7 +195,7 @@ void SphSimulation<ndim>::ProcessParameters(void)
   sinks->smooth_accrete_dt   = floatparams["smooth_accrete_dt"];
   sinks->sink_radius_mode    = stringparams["sink_radius_mode"];
   sinks->rho_sink            = floatparams["rho_sink"];
-  sinks->rho_sink            /= simunits.rho.outscale/simunits.rho.outcgs;
+  sinks->rho_sink            /= (simunits.rho.outscale*simunits.rho.outcgs);
 
   if (sinks->sink_radius_mode == "fixed") {
     sinks->sink_radius = floatparams["sink_radius"]/simunits.r.outscale;

--- a/src/MeshlessFV/MeshlessFV.cpp
+++ b/src/MeshlessFV/MeshlessFV.cpp
@@ -94,9 +94,9 @@ void MeshlessFV<ndim>::AllocateMemory(int N)
     if (allocated) DeallocateMemory();
 
     // Set conservative estimate for maximum number of particles, assuming
-    // extra space required for periodic ghost particles
+    // extra space required for (periodic) ghost particles
     if (Nhydromax < N) {
-      Nhydromax = 2*(int) powf(powf((FLOAT) N,invndim) + (FLOAT) 8.0*kernp->kernrange,ndim);
+      Nhydromax = 2*(int) powf(powf((FLOAT) N,invndim) + (FLOAT) 16.0*kernp->kernrange,ndim);
     }
 
     iorder    = new int[Nhydromax];
@@ -277,7 +277,7 @@ void MeshlessFV<ndim>::EndTimestep
 
       // Integrate all conserved quantities to end of the step (adding sums from neighbours)
       for (int var=0; var<nvar; var++) {
-        part.Qcons[var] += part.dQ[var]; //+ part.dQdt[var]*timestep*(FLOAT) nstep;
+        part.Qcons[var] += part.dQ[var];
       }
 
       // Further update conserved quantities if computing gravitational contributions

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -777,7 +777,7 @@ void MeshlessFVTree<ndim,ParticleType,TreeCell>::UpdateGodunovFluxes
           // (to only calculate each pair once).
           if (neibpart[jj].itype == dead || neiblist[jj] == i ||
               activepart[j].level < neibpart[jj].level ||
-              (neiblist[jj] < i && neibpart[jj].level == activepart[j].level)) continue;
+              (neibpart[jj].iorig < i && neibpart[jj].level == activepart[j].level)) continue;
 
           // Compute relative position and distance quantities for pair
           for (k=0; k<ndim; k++) draux[k] = neibpart[jj].r[k] - rp[k];
@@ -829,10 +829,13 @@ void MeshlessFVTree<ndim,ParticleType,TreeCell>::UpdateGodunovFluxes
 #pragma omp critical
     {
       for (i=0; i<Nhydro; i++) {
-        //for (k=0; k<ndim+2; k++) mfvdata[i].dQdt[k] += fluxBuffer[i][k];
-        //for (k=0; k<ndim; k++) mfvdata[i].rdmdt[k] += rdmdtBuffer[i][k];
         for (k=0; k<ndim+2; k++) mfvdata[i].dQ[k] += fluxBuffer[i][k];
         for (k=0; k<ndim; k++) mfvdata[i].rdmdt[k] += rdmdtBuffer[i][k];
+      }
+      for (j=Nhydro; j<Nhydro+mfv->NPeriodicGhost; j++) {
+        i = mfvdata[j].iorig;
+        for (k=0; k<ndim+2; k++) mfvdata[i].dQ[k] += fluxBuffer[j][k];
+        for (k=0; k<ndim; k++) mfvdata[i].rdmdt[k] += rdmdtBuffer[j][k];
       }
     }
 

--- a/src/MeshlessFV/MfvMuscl.cpp
+++ b/src/MeshlessFV/MfvMuscl.cpp
@@ -116,8 +116,7 @@ int MfvMuscl<ndim, kernelclass>::ComputeH
     part.hfactor  = pow(part.invh,ndim);
     invhsqd       = part.invh*part.invh;
 
-    // Loop over all nearest neighbours in list to calculate
-    // density, omega and zeta.
+    // Loop over all nearest neighbours in list to calculate density, omega and zeta.
     //---------------------------------------------------------------------------------------------
     for (j=0; j<Nneib; j++) {
       ssqd           = drsqd[j]*invhsqd;
@@ -200,12 +199,7 @@ int MfvMuscl<ndim, kernelclass>::ComputeH
 
 //=================================================================================================
 //  MfvMuscl::ComputeDerivatives
-/// Compute SPH neighbour force pairs for
-/// (i) All neighbour interactions of particle i with i.d. j > i,
-/// (ii) Active neighbour interactions of particle j with i.d. j > i
-/// (iii) All inactive neighbour interactions of particle i with i.d. j < i.
-/// This ensures that all particle-particle pair interactions are only
-/// computed once only for efficiency.
+/// Compute Psi factors required for computing derivatives needed in Meshess FV equations.
 //=================================================================================================
 template <int ndim, template<int> class kernelclass>
 void MfvMuscl<ndim, kernelclass>::ComputePsiFactors
@@ -286,12 +280,7 @@ void MfvMuscl<ndim, kernelclass>::ComputePsiFactors
 
 //=================================================================================================
 //  MfvMuscl::ComputeDerivatives
-/// Compute SPH neighbour force pairs for
-/// (i) All neighbour interactions of particle i with i.d. j > i,
-/// (ii) Active neighbour interactions of particle j with i.d. j > i
-/// (iii) All inactive neighbour interactions of particle i with i.d. j < i.
-/// This ensures that all particle-particle pair interactions are only
-/// computed once only for efficiency.
+/// Compute derivatives required for Meshless FV equations.
 //=================================================================================================
 template <int ndim, template<int> class kernelclass>
 void MfvMuscl<ndim, kernelclass>::ComputeGradients
@@ -498,7 +487,7 @@ void MfvMuscl<ndim, kernelclass>::ComputeGodunovFlux
   int jj;                              // Aux. neighbour counter
   int k;                               // Dimension counter
   int var;                             // Particle state vector variable counter
-  FLOAT Aij[ndim];                     // ??
+  FLOAT Aij[ndim];                     // Pseudo 'Area' vector
   FLOAT draux[ndim];                   // Position vector of part relative to neighbour
   FLOAT dr_unit[ndim];                 // Unit vector from neighbour to part
   FLOAT drsqd;                         // Distance squared
@@ -550,8 +539,9 @@ void MfvMuscl<ndim, kernelclass>::ComputeGodunovFlux
       for (k=0; k<ndim; k++) vface[k] = (FLOAT) 0.0;
     }
     else {
-      for (k=0; k<ndim; k++) rface[k] = part.r[k] +
-        part.h*(neibpart[j].r[k] - part.r[k])/(part.h + neibpart[j].h);
+      for (k=0; k<ndim; k++) rface[k] = (FLOAT) 0.5*(part.r[k] + neibpart[j].r[k]);
+      //for (k=0; k<ndim; k++) rface[k] = part.r[k] +
+      //  part.h*(neibpart[j].r[k] - part.r[k])/(part.h + neibpart[j].h);
       for (k=0; k<ndim; k++) draux[k] = part.r[k] - rface[k];
       for (k=0; k<ndim; k++) vface[k] = part.v[k] +
         (neibpart[j].v[k] - part.v[k])*DotProduct(draux, dr_unit, ndim)*invdrmagaux;
@@ -581,11 +571,11 @@ void MfvMuscl<ndim, kernelclass>::ComputeGodunovFlux
     assert(Wleft[ipress] > 0.0);
     assert(Wright[irho] > 0.0);
     assert(Wright[ipress] > 0.0);
-    if (part.nstep > neibpart[j].nstep) {
+    /*if (part.nstep > neibpart[j].nstep) {
       cout << "TIMESTEP PROBLEM : " << part.nstep << "   " << part.level << "    neib : "
            << neibpart[j].nstep << "    " << neibpart[j].level << endl;
-    }
-    assert(part.nstep <= neibpart[j].nstep);
+    }*/
+    //assert(part.nstep <= neibpart[j].nstep);
 
 
     // Calculate Godunov flux using the selected Riemann solver

--- a/src/MeshlessFV/MfvMusclSimulation.cpp
+++ b/src/MeshlessFV/MfvMusclSimulation.cpp
@@ -98,29 +98,6 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
   mfvneib->UpdateGodunovFluxes(mfv->Nhydro, mfv->Ntot, timestep, partdata, mfv, nbody);
 
 
-  /*if (Nsteps%1 == 0) {
-  stringstream ss;
-  string nostring = "";
-  ss << setfill('0') << setw(5) << Nsteps;
-  nostring = ss.str();
-  string filename = run_id + ".SLOPES." + nostring;
-  ss.str(std::string());
-  ofstream outfile;
-  outfile.open(filename.c_str());
-  for (i=0; i<mfv->Nhydro; i++) {
-    for (k=0; k<ndim; k++) outfile << partdata[i].r[k] << "    ";
-    for (k=0; k<ndim+2; k++) outfile << partdata[i].Wprim[k] << "    ";
-    for (k=0; k<ndim+2; k++) {
-      for (int kk=0; kk<ndim; kk++) outfile << partdata[i].grad[k][kk] << "    ";
-    }
-    for (k=0; k<ndim+2; k++) outfile << partdata[i].dQdt[k] << "    ";
-    outfile << endl;
-  }
-  outfile.close();
-  cout << "WROTE FILE : " << filename << endl;
-}*/
-
-
   // Integrate all conserved variables to end of timestep
   //-----------------------------------------------------------------------------------------------
   if (!mfv->staticParticles) {
@@ -261,10 +238,10 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
 
 
   // End-step terms for all hydro particles
-  mfv->EndTimestep(n, mfv->Nhydro, t, timestep, mfv->GetMeshlessFVParticleArray());
+  mfv->EndTimestep(n, mfv->Nhydro, t, timestep, partdata);
 
   // End-step terms for all star particles
-  if (nbody->Nstar > 0) nbody->EndTimestep(n,nbody->Nnbody,t,timestep,nbody->nbodydata);
+  if (nbody->Nstar > 0) nbody->EndTimestep(n, nbody->Nnbody, t, timestep, nbody->nbodydata);
 
 
   // Search for new sink particles (if activated) and accrete to existing sinks

--- a/src/Tree/KDTree.cpp
+++ b/src/Tree/KDTree.cpp
@@ -969,7 +969,7 @@ void KDTree<ndim,ParticleType,TreeCell>::ExtrapolateCellProperties
   debug2("[KDTree::ExtrapolateCellProperties]");
 
 
-  // ...
+  // ..
   //-----------------------------------------------------------------------------------------------
   for (c=0; c<Ncell; c++) {
 
@@ -1138,7 +1138,7 @@ void KDTree<ndim,ParticleType,TreeCell>::UpdateWorkCounters
 
   // If cell is not leaf, stock child cells
   //-----------------------------------------------------------------------------------------------
-  if (cell.level != ltot) {
+  if (cell.level != ltot && cell.c1 >= 0) {
 #if defined _OPENMP
     if (pow(2,cell.level) < Nthreads) {
 #pragma omp parallel for default(none) private(i) shared(cell) num_threads(2)
@@ -1165,7 +1165,7 @@ void KDTree<ndim,ParticleType,TreeCell>::UpdateWorkCounters
 
   // If this is a leaf cell, sum over all particles
   //-----------------------------------------------------------------------------------------------
-  if (cell.level == ltot) {
+  if (cell.level < ltot) {
     cell.worktot = (FLOAT) 0.0;
     cc = cell.c1;
     ccc = cell.c2;

--- a/tests/adsod.dat
+++ b/tests/adsod.dat
@@ -8,7 +8,7 @@
 # Initial conditions variables
 #-----------------------------
 Simulation run id string                    : run_id = ADSOD1
-Select SPH simulation                       : sim = sph
+Select SPH simulation                       : sim = gradhsph
 Select shocktube initial conditions         : ic = shocktube
 1D shocktube test                           : ndim = 1
 x-velocity of LHS fluid                     : vfluid1[0] = 0.0


### PR DESCRIPTION
1. Fixed meshless scheme for block timesteps.  Should work for open and periodic boundaries (unsure about mirror boundaries but since this is possibly being changed soon, I'll leave this for now)
2. Userguide has been updated to include section on units
3. Some other smaller changes, including fixing a small potential problem with scaling the sink density