### PR TITLE
Added check to kill the simulation when smoothing length is too large…

### DIFF
--- a/src/Headers/NeighbourSearch.h
+++ b/src/Headers/NeighbourSearch.h
@@ -91,6 +91,7 @@ protected:
   virtual void UpdateActiveParticleCounters(Particle<ndim> *, Hydrodynamics<ndim> *) = 0;
   virtual void UpdateAllStarGasForces(int, int, Particle<ndim> *,
                                       Hydrodynamics<ndim> *, Nbody<ndim> *) = 0;
+  virtual double GetMaximumSmoothingLength() = 0 ;
 #ifdef MPI_PARALLEL
   virtual void BuildPrunedTree(const int, const int, const DomainBox<ndim> &,
                                const MpiNode<ndim> *, Particle<ndim> *) = 0;
@@ -182,6 +183,8 @@ class BruteForceSearch : public virtual NeighbourSearch<ndim>
   virtual void UpdateActiveParticleCounters(Particle<ndim> *, Hydrodynamics<ndim> *) {};
   virtual void UpdateAllStarGasForces(int, int, Particle<ndim> *,
                                       Hydrodynamics<ndim> *, Nbody<ndim> *);
+  virtual double GetMaximumSmoothingLength() { return _Hmax ; }
+
 #ifdef MPI_PARALLEL
   virtual void BuildPrunedTree(const int, const int, const DomainBox<ndim> &,
                                const MpiNode<ndim> *, Particle<ndim> *) {};
@@ -209,6 +212,8 @@ class BruteForceSearch : public virtual NeighbourSearch<ndim>
   virtual void FindParticlesToTransfer(Hydrodynamics<ndim> *, vector<vector<int> >& ,
                                        vector<int> &, const vector<int> &, MpiNode<ndim> *);
 #endif
+
+  double _Hmax ;
 
 };
 
@@ -257,6 +262,7 @@ protected:
   virtual void UpdateActiveParticleCounters(Particle<ndim> *, Hydrodynamics<ndim> *);
   virtual void UpdateAllStarGasForces(int, int, Particle<ndim> *,
                                       Hydrodynamics<ndim> *, Nbody<ndim> *);
+  virtual double GetMaximumSmoothingLength() ;
 #ifdef MPI_PARALLEL
   virtual void BuildPrunedTree(const int, const int, const DomainBox<ndim> &,
                                const MpiNode<ndim> *, Particle<ndim> *);

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -833,7 +833,7 @@ void SphSimulation<ndim>::MainLoop(void)
     double hmax = sphneib->GetMaximumSmoothingLength() ;
     hmax *= sph->kernp->kernrange ;
     for (i=0; i < ndim; i++)
-      if (simbox.boxhalf[i] < hmax){
+      if (simbox.boxhalf[i] < 2*hmax){
         string message = "Error: Smoothing length too large, self-interaction will occur" ;
     	ExceptionHandler::getIstance().raise(message);
       }

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -828,6 +828,16 @@ void SphSimulation<ndim>::MainLoop(void)
   //-----------------------------------------------------------------------------------------------
 
 
+  /* Check that we have sensible smoothing lengths */
+  if (periodicBoundaries) {
+    double hmax = sphneib->GetMaximumSmoothingLength() ;
+    hmax *= sph->kernp->kernrange ;
+    for (i=0; i < ndim; i++)
+      if (simbox.boxhalf[i] < hmax){
+        string message = "Error: Smoothing length too large, self-interaction will occur" ;
+    	ExceptionHandler::getIstance().raise(message);
+      }
+  }
 
   // Iterate for P(EC)^n schemes for N-body particles
   //-----------------------------------------------------------------------------------------------

--- a/src/MeshlessFV/MfvMusclSimulation.cpp
+++ b/src/MeshlessFV/MfvMusclSimulation.cpp
@@ -223,6 +223,17 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
   mfvneib->UpdateGradientMatrices(mfv->Nhydro, mfv->Ntot, partdata, mfv, nbody, simbox);
   mfv->CopyDataToGhosts(simbox, partdata);
 
+  /* Check that we have sensible smoothing lengths */
+  if (periodicBoundaries) {
+    double hmax = mfvneib->GetMaximumSmoothingLength() ;
+    hmax *= mfv->kernp->kernrange ;
+    for (i=0; i < ndim; i++)
+      if (simbox.boxhalf[i] < 2*hmax){
+        string message = "Error: Smoothing length too large, self-interaction will occur" ;
+    	ExceptionHandler::getIstance().raise(message);
+      }
+  }
+
   return;
 }
 

--- a/src/MeshlessFV/MfvRungeKuttaSimulation.cpp
+++ b/src/MeshlessFV/MfvRungeKuttaSimulation.cpp
@@ -501,6 +501,17 @@ void MfvRungeKuttaSimulation<ndim>::MainLoop(void)
 
 */
 
+  /* Check that we have sensible smoothing lengths */
+  if (periodicBoundaries) {
+    double hmax = mfvneib->GetMaximumSmoothingLength() ;
+    hmax *= mfv->kernp->kernrange ;
+    for (i=0; i < ndim; i++)
+      if (simbox.boxhalf[i] < 2*hmax){
+        string message = "Error: Smoothing length too large, self-interaction will occur" ;
+    	ExceptionHandler::getIstance().raise(message);
+      }
+  }
+
 
   return;
 }

--- a/src/Tree/BruteForceSearch.cpp
+++ b/src/Tree/BruteForceSearch.cpp
@@ -60,6 +60,19 @@ void BruteForceSearch<ndim,ParticleType>::BuildTree
   Hydrodynamics<ndim> *hydro)          ///< [inout] Pointer to Hydrodynamics object
 {
   hydro->DeleteDeadParticles();
+
+  ParticleType<ndim>* partdata = static_cast<ParticleType<ndim>* > (part_gen);
+
+  /* Save the maximum smoothing length for later */
+  double hmax = 0 ;
+  for (int n=0; n < Npart; n++)
+    if (partdata[n].h > hmax)
+    	hmax = partdata[n].h ;
+#if defined MPI_PARALLEL
+  double hmax_local = hmax ;
+  	 MPI_AllReduce(&hmax_local, &hmax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD) ;
+#endif
+  _Hmax = hmax ;
   return;
 }
 
@@ -232,8 +245,6 @@ void BruteForceSearch<ndim,ParticleType>::UpdateAllStarGasForces
 
   return;
 }
-
-
 
 #if defined MPI_PARALLEL
 //=================================================================================================

--- a/src/Tree/BruteForceSearch.cpp
+++ b/src/Tree/BruteForceSearch.cpp
@@ -70,7 +70,7 @@ void BruteForceSearch<ndim,ParticleType>::BuildTree
     	hmax = partdata[n].h ;
 #if defined MPI_PARALLEL
   double hmax_local = hmax ;
-  	 MPI_AllReduce(&hmax_local, &hmax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD) ;
+  	 MPI_Allreduce(&hmax_local, &hmax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD) ;
 #endif
   _Hmax = hmax ;
   return;

--- a/src/Tree/HydroTree.cpp
+++ b/src/Tree/HydroTree.cpp
@@ -883,7 +883,20 @@ void HydroTree<ndim,ParticleType,TreeCell>::UpdateAllStarGasForces
 
   return;
 }
+//=================================================================================================
+template <int ndim, template<int> class ParticleType, template<int> class TreeCell>
+double HydroTree<ndim,ParticleType,TreeCell>::GetMaximumSmoothingLength()
+{
+  assert(tree != NULL) ;
+  assert(tree->celldata != NULL) ;
+  double hmax = tree->celldata[0].hmax ;
 
+#if defined MPI_PARALLEL
+  for (int n = 0; n < Nmpi; n++)
+	hmax = std::max(hmax, prunedtree[n]->celldata[0].hmax) ;
+#endif
+  return hmax ;
+}
 
 
 #ifdef MPI_PARALLEL


### PR DESCRIPTION
… - only if periodic/reflecting boundaries are used.

I've tested it by varying the number of neighbours in a sod shock tube test. It seems to work fine. Not tested with MPI.