### PR TITLE
Timestep limiter

### DIFF
--- a/docs/userguide.tex
+++ b/docs/userguide.tex
@@ -713,6 +713,13 @@ minmod        & = simplified implementation of minmod slope limiter
 \item \var{zero\_mass\_flux} : Use Meshless-Finite Mass scheme to prevent mass-flux between particles?   ($1$ or $0$)
 \item \var{static\_particles} : Use static particles (Eulerian approach)?  ($1$ or $0$)
 
+\item \var{time\_step\_limiter} : Use an additional limiter on the time-steps \\
+\begin{tabular}{ll}
+none		 & = No additional limiter \\
+conservative & = Predictive global timestep limiter of Springel (2009) \\
+simple		 & = Saitoh \& Makino type limiter. Reduces the time step if it is detected to be too large.
+\end{tabular}
+
 \end{itemize}
 
 

--- a/src/Common/Parameters.cpp
+++ b/src/Common/Parameters.cpp
@@ -278,10 +278,11 @@ void Parameters::SetDefaultValues(void)
 
   // Meshless Finite-Volume parameters
   //-----------------------------------------------------------------------------------------------
-  stringparams["riemann_solver"] = "exact";
-  stringparams["slope_limiter"] = "springel2009";
-  intparams["zero_mass_flux"] = 0;
+  stringparams["riemann_solver"] = "hllc";
+  stringparams["slope_limiter"] = "gizmo";
+  intparams["zero_mass_flux"] = 1;
   intparams["static_particles"] = 0;
+  stringparams["time_step_limiter"] = "none";
 
   // Gravity parameters
   //-----------------------------------------------------------------------------------------------

--- a/src/Headers/BruteForceTree.h
+++ b/src/Headers/BruteForceTree.h
@@ -100,7 +100,7 @@ class BruteForceTree : public Tree<ndim,ParticleType,TreeCell>
   // Constructor and destructor
   //-----------------------------------------------------------------------------------------------
   BruteForceTree(int, FLOAT, FLOAT, FLOAT, string, string, const DomainBox<ndim>&,
-		  	  	 const ParticleTypeRegister& reg);
+		  	  	 const ParticleTypeRegister& reg,const bool);
   ~BruteForceTree() ;
 
 

--- a/src/Headers/GhostNeighbours.hpp
+++ b/src/Headers/GhostNeighbours.hpp
@@ -94,8 +94,8 @@ public:
 	  _need_mirrors = false ;
 	  for (int k=0; k < ndim; k++){
 		_centre[k] = cell.rcell[k] ;
-		_cell.min[k] = cell.bbox.min[k] ;
-		_cell.max[k] = cell.bbox.max[k] ;
+		_cell.min[k] = cell.bb.min[k] ;
+		_cell.max[k] = cell.bb.max[k] ;
         _hbox.min[k] = cell.hbox.min[k] ;
         _hbox.max[k] = cell.hbox.max[k] ;
         _vbox.min[k] = cell.vbox.min[k] ;

--- a/src/Headers/KDTree.h
+++ b/src/Headers/KDTree.h
@@ -111,7 +111,7 @@ class KDTree : public Tree<ndim,ParticleType,TreeCell>
   // Constructor and destructor
   //-----------------------------------------------------------------------------------------------
   KDTree(int, FLOAT, FLOAT, FLOAT, string, string, const DomainBox<ndim>&,
-		 const ParticleTypeRegister&);
+		 const ParticleTypeRegister&,const bool);
   ~KDTree();
 
 

--- a/src/Headers/MeshlessFV.h
+++ b/src/Headers/MeshlessFV.h
@@ -135,8 +135,7 @@ public:
   void InitialSmoothingLengthGuess(void);
   void IntegrateParticles(const int, const int, const FLOAT, const FLOAT,
                           const DomainBox<ndim> &, MeshlessFVParticle<ndim> *);
-  int CheckTimesteps(const int, const int, const int, const int, double,
-                     MeshlessFVParticle<ndim>*, int);
+  int CheckTimesteps(const int, const int, const int, double, int);
 
   FLOAT Timestep(MeshlessFVParticle<ndim> &);
   void UpdatePrimitiveVector(MeshlessFVParticle<ndim> &);

--- a/src/Headers/MeshlessFV.h
+++ b/src/Headers/MeshlessFV.h
@@ -135,6 +135,9 @@ public:
   void InitialSmoothingLengthGuess(void);
   void IntegrateParticles(const int, const int, const FLOAT, const FLOAT,
                           const DomainBox<ndim> &, MeshlessFVParticle<ndim> *);
+  int CheckTimesteps(const int, const int, const int, const int, double,
+                     MeshlessFVParticle<ndim>*, int);
+
   FLOAT Timestep(MeshlessFVParticle<ndim> &);
   void UpdatePrimitiveVector(MeshlessFVParticle<ndim> &);
   void UpdateArrayVariables(MeshlessFVParticle<ndim> &, FLOAT [nvar]);
@@ -168,9 +171,10 @@ public:
   FLOAT hmin_sink;                     ///< Minimum smoothing length of sinks
   string riemann_solver;               ///< Selected Riemann solver
   string slope_limiter;                ///< Selected slope limiter
-  //MeshlessFVType MeshlessFVtype[Ntypes];        ///< Array of MeshlessFV types
+  string timestep_limiter;            ///< Time of limiter used for block timesteps
 
   MeshlessFVParticle<ndim> *hydrodata;
+  CodeTiming* timing;
 
 };
 

--- a/src/Headers/NeighbourSearch.h
+++ b/src/Headers/NeighbourSearch.h
@@ -89,7 +89,7 @@ protected:
   virtual TreeBase<ndim>* GetGhhotTree() const = 0;
   virtual void SetTimingObject(CodeTiming*) = 0 ;
   virtual void ToggleNeighbourCheck(bool do_check) = 0 ;
-  virtual void UpdateTimestepsLimitsFromDistantParticles(Hydrodynamics<ndim>*) = 0 ;
+  virtual void UpdateTimestepsLimitsFromDistantParticles(Hydrodynamics<ndim>*,const bool) = 0 ;
 
 #ifdef MPI_PARALLEL
   virtual TreeBase<ndim>** GetPrunedTrees() const = 0;
@@ -145,6 +145,7 @@ class HydroTree : public virtual NeighbourSearch<ndim>
   vector<vector<int> > ids_sent_cells;
   vector<int> N_imported_part_per_proc;
   vector<int> N_imported_cells_per_proc;
+  int rank;
 protected:
 #endif
  public:
@@ -171,7 +172,7 @@ protected:
   virtual void SetTimingObject(CodeTiming* timer) { timing = timer ; }
   virtual void ToggleNeighbourCheck(bool do_check) { neibcheck = do_check; }
 
-  virtual void UpdateTimestepsLimitsFromDistantParticles(Hydrodynamics<ndim>*);
+  virtual void UpdateTimestepsLimitsFromDistantParticles(Hydrodynamics<ndim>*,const bool);
 
 #ifdef MPI_PARALLEL
   virtual TreeBase<ndim>** GetPrunedTrees() const { return prunedtree; }
@@ -308,7 +309,8 @@ protected:
                              FLOAT kernrange, FLOAT macerror,
                              string gravity_mac, string multipole,
                              const DomainBox<ndim>& domain,
-                             const ParticleTypeRegister& reg) ;
+                             const ParticleTypeRegister& reg,
+							 const bool IAmPruned) ;
 };
 
 

--- a/src/Headers/NeighbourSearch.h
+++ b/src/Headers/NeighbourSearch.h
@@ -89,6 +89,7 @@ protected:
   virtual TreeBase<ndim>* GetGhhotTree() const = 0;
   virtual void SetTimingObject(CodeTiming*) = 0 ;
   virtual void ToggleNeighbourCheck(bool do_check) = 0 ;
+  virtual void UpdateTimestepsLimitsFromDistantParticles(int, int, Particle<ndim> *) = 0 ;
 
 #ifdef MPI_PARALLEL
   virtual TreeBase<ndim>** GetPrunedTrees() const = 0;
@@ -170,6 +171,7 @@ protected:
   virtual void SetTimingObject(CodeTiming* timer) { timing = timer ; }
   virtual void ToggleNeighbourCheck(bool do_check) { neibcheck = do_check; }
 
+  virtual void UpdateTimestepsLimitsFromDistantParticles(int, int, Particle<ndim> *);
 
 #ifdef MPI_PARALLEL
   virtual TreeBase<ndim>** GetPrunedTrees() const { return prunedtree; }

--- a/src/Headers/NeighbourSearch.h
+++ b/src/Headers/NeighbourSearch.h
@@ -89,7 +89,7 @@ protected:
   virtual TreeBase<ndim>* GetGhhotTree() const = 0;
   virtual void SetTimingObject(CodeTiming*) = 0 ;
   virtual void ToggleNeighbourCheck(bool do_check) = 0 ;
-  virtual void UpdateTimestepsLimitsFromDistantParticles(int, int, Particle<ndim> *) = 0 ;
+  virtual void UpdateTimestepsLimitsFromDistantParticles(Hydrodynamics<ndim>*) = 0 ;
 
 #ifdef MPI_PARALLEL
   virtual TreeBase<ndim>** GetPrunedTrees() const = 0;
@@ -171,7 +171,7 @@ protected:
   virtual void SetTimingObject(CodeTiming* timer) { timing = timer ; }
   virtual void ToggleNeighbourCheck(bool do_check) { neibcheck = do_check; }
 
-  virtual void UpdateTimestepsLimitsFromDistantParticles(int, int, Particle<ndim> *);
+  virtual void UpdateTimestepsLimitsFromDistantParticles(Hydrodynamics<ndim>*);
 
 #ifdef MPI_PARALLEL
   virtual TreeBase<ndim>** GetPrunedTrees() const { return prunedtree; }

--- a/src/Headers/OctTree.h
+++ b/src/Headers/OctTree.h
@@ -127,7 +127,7 @@ class OctTree : public Tree<ndim,ParticleType,TreeCell>
   // Constructor and destructor
   //-----------------------------------------------------------------------------------------------
   OctTree(int, FLOAT, FLOAT, FLOAT, string, string, const DomainBox<ndim>&,
-		  const ParticleTypeRegister&);
+		  const ParticleTypeRegister&, const bool);
   ~OctTree();
 
 

--- a/src/Headers/Particle.h
+++ b/src/Headers/Particle.h
@@ -258,6 +258,7 @@ struct Particle
   FLOAT mu_bar;                     ///< mean molecular weight
   FLOAT ueq;                        ///< equilibrium internal energy
   FLOAT dt_therm;                   ///< thermalization time scale
+  FLOAT vsig_max;                   ///< Maximum signal velocity.
   FLOAT rad_pres[ndim];             ///< Acceleration from radiation pressure cmscott
   int ionstate;                     ///< States current ionisation state of the particle
                                     ///< (0 is neutral, 1 is smoothed and 2 is ionised)
@@ -293,6 +294,7 @@ struct Particle
     ionfrac   = (FLOAT) 0.999;
     Xion      = (FLOAT) 0.999;
     mu_bar    = (FLOAT) 1.0;
+    vsig_max  = 0;
   }
 
 };
@@ -418,7 +420,7 @@ struct MeshlessFVParticle : public Particle<ndim>
   FLOAT press;                         ///< Pressure
   FLOAT invomega;                      ///< ..
   FLOAT div_v;                         ///< Velocity divergence
-  FLOAT vsig_max;                      ///< Maximum signal velocity to all neighbours
+  //FLOAT vsig_max;                      ///< Maximum signal velocity to all neighbours
   FLOAT ndens;                         ///< Particle number density, inverse volume
   FLOAT zeta;                          ///< ..
   FLOAT B[ndim][ndim];                 ///< Inverse matrix for gradient calculations
@@ -438,7 +440,7 @@ struct MeshlessFVParticle : public Particle<ndim>
     press     = (FLOAT) 0.0;
     div_v     = (FLOAT) 0.0;
     ndens     = (FLOAT) 0.0;
-    vsig_max  = (FLOAT) 0.0;
+   // vsig_max  = (FLOAT) 0.0;
     zeta      = (FLOAT) 0.0;
     for (int k=0; k<ndim; k++) rdmdt[k] = (FLOAT) 0.0;
     for (int k=0; k<ndim; k++) rdmdt0[k] = (FLOAT) 0.0;

--- a/src/Headers/Particle.h
+++ b/src/Headers/Particle.h
@@ -267,6 +267,7 @@ struct Particle
     iorig = -1;
     flags = none;
     ptype = gas_type;
+    levelneib = 0;
     level = 0;
     nstep = 0;
     nlast = 0;

--- a/src/Headers/Simulation.h
+++ b/src/Headers/Simulation.h
@@ -658,6 +658,7 @@ class MeshlessFVSimulation : public Simulation<ndim>
   MeshlessFV<ndim> *mfv;                       ///< Meshless FV hydrodynamics algorithm pointer
   MeshlessFVNeighbourSearch<ndim> *mfvneib;    ///< Meshless FV neighbour search object pointer
 
+  string time_step_limiter_type;               ///< Time step limiting algorithm to employ
 };
 
 
@@ -737,6 +738,7 @@ class MfvMusclSimulation : public MeshlessFVSimulation<ndim>
   using Simulation<ndim>::radiation;
   using MeshlessFVSimulation<ndim>::mfv;
   using MeshlessFVSimulation<ndim>::mfvneib;
+  using MeshlessFVSimulation<ndim>::time_step_limiter_type;
 #ifdef MPI_PARALLEL
   using Simulation<ndim>::mpicontrol;
   using Simulation<ndim>::MpiGhosts;
@@ -834,6 +836,7 @@ class MfvRungeKuttaSimulation : public MeshlessFVSimulation<ndim>
   using Simulation<ndim>::radiation;
   using MeshlessFVSimulation<ndim>::mfv;
   using MeshlessFVSimulation<ndim>::mfvneib;
+  using MeshlessFVSimulation<ndim>::time_step_limiter_type;
 #ifdef MPI_PARALLEL
   using Simulation<ndim>::mpicontrol;
   using Simulation<ndim>::MpiGhosts;

--- a/src/Headers/Tree.h
+++ b/src/Headers/Tree.h
@@ -73,6 +73,7 @@ struct TreeCellBase {
   FLOAT m;                             ///< Mass contained in cell
   FLOAT rmax;                          ///< Radius of bounding sphere
   FLOAT hmax;                          ///< Maximum smoothing length inside cell
+  FLOAT maxsound;                      ///< Maximum sound speed inside the cell
   FLOAT drmaxdt;                       ///< Rate of change of bounding sphere
   FLOAT dhmaxdt;                       ///< Rate of change of maximum h
   FLOAT q[5];                          ///< Quadrupole moment tensor
@@ -171,6 +172,11 @@ class TreeBase
 	virtual  bool ComputeHydroTreeCellOverlap(const TreeCellBase<ndim> *, const DomainBox<ndim> &) = 0;
 	virtual  FLOAT ComputeWorkInBox(const FLOAT *, const FLOAT *) = 0;
 #endif
+
+	virtual void ComputeSignalVelocityFromDistantInteractions(const TreeCellBase<ndim>& cell,
+	                                                          int Nactive, Particle<ndim>* active_gen,
+	                                                          Particle<ndim>* part_gen) = 0;
+
 	virtual int FindLeafCell(const FLOAT *) = 0;
 
 	//-----------------------------------------------------------------------------------------------
@@ -308,6 +314,10 @@ protected:
   int ComputeStarGravityInteractionList(const NbodyParticle<ndim> *, const FLOAT, const int,
                                         const int, const int, int &, int &, int &, int *, int *,
                                         MultipoleMoment<ndim> *, Particle<ndim> *);
+
+  virtual void ComputeSignalVelocityFromDistantInteractions(const TreeCellBase<ndim>& cell,
+                                                            int Nactive, Particle<ndim>* active_gen,
+                                                            Particle<ndim>* part_gen);
   virtual int FindLeafCell(const FLOAT *);
 #ifdef MPI_PARALLEL
   int CreatePrunedTreeForMpiNode(const MpiNode<ndim> &, const DomainBox<ndim> &, const FLOAT,

--- a/src/Headers/Tree.h
+++ b/src/Headers/Tree.h
@@ -165,6 +165,7 @@ class TreeBase
 	                                              const int, const int, int &, int &, int &, int *, int *,
 	                                              MultipoleMoment<ndim> *, Particle<ndim> *) = 0;
 #if defined(MPI_PARALLEL)
+	virtual int ComputeImportedCellList(vector<TreeCellBase<ndim> >& ) = 0;
 	virtual int CreatePrunedTreeForMpiNode(const MpiNode<ndim> &, const DomainBox<ndim> &, const FLOAT,
 	                                       const bool, const int, const int, const int, TreeBase<ndim> *) = 0;
 	virtual int ComputeDistantGravityInteractionList(const TreeCellBase<ndim>&, const DomainBox<ndim> &,
@@ -173,7 +174,7 @@ class TreeBase
 	virtual  FLOAT ComputeWorkInBox(const FLOAT *, const FLOAT *) = 0;
 #endif
 
-	virtual void ComputeSignalVelocityFromDistantInteractions(const TreeCellBase<ndim>& cell,
+	virtual bool ComputeSignalVelocityFromDistantInteractions(const TreeCellBase<ndim>& cell,
 	                                                          int Nactive, Particle<ndim>* active_gen,
 	                                                          Particle<ndim>* part_gen) = 0;
 
@@ -264,16 +265,17 @@ class Tree : public TreeBase<ndim>
 protected:
 	int Ncellmax;                        ///< Max. allowed no. of grid cells
 	int Ntotmax;                         ///< Max. no. of points in list
+	const bool IAmPruned;				 ///< Whether we are a pruned tree
  public:
 
 
   Tree(int _Nleafmax, FLOAT _thetamaxsqd, FLOAT _kernrange, FLOAT _macerror,
        string _gravity_mac, string _multipole, const DomainBox<ndim>& domain,
-       const ParticleTypeRegister& pt_reg) :
+       const ParticleTypeRegister& pt_reg,const bool _IAmPruned) :
     gravity_mac(_gravity_mac), multipole(_multipole), Nleafmax(_Nleafmax),
     invthetamaxsqd(1.0/_thetamaxsqd), kernrange(_kernrange), macerror(_macerror),
     theta(sqrt(_thetamaxsqd)), thetamaxsqd(_thetamaxsqd), _domain(domain),
-    gravmask(pt_reg.gravmask)
+    gravmask(pt_reg.gravmask), IAmPruned(_IAmPruned)
     {};
 
   virtual ~Tree() { } ;
@@ -315,11 +317,12 @@ protected:
                                         const int, const int, int &, int &, int &, int *, int *,
                                         MultipoleMoment<ndim> *, Particle<ndim> *);
 
-  virtual void ComputeSignalVelocityFromDistantInteractions(const TreeCellBase<ndim>& cell,
+  virtual bool ComputeSignalVelocityFromDistantInteractions(const TreeCellBase<ndim>& cell,
                                                             int Nactive, Particle<ndim>* active_gen,
                                                             Particle<ndim>* part_gen);
   virtual int FindLeafCell(const FLOAT *);
 #ifdef MPI_PARALLEL
+  int ComputeImportedCellList(vector<TreeCellBase<ndim> >& );
   int CreatePrunedTreeForMpiNode(const MpiNode<ndim> &, const DomainBox<ndim> &, const FLOAT,
                                  const bool, const int, const int, const int, TreeBase<ndim> *);
   int ComputeDistantGravityInteractionList(const TreeCellBase<ndim>&, const DomainBox<ndim> &,

--- a/src/Hydrodynamics/SphLeapfrogKDK.cpp
+++ b/src/Hydrodynamics/SphLeapfrogKDK.cpp
@@ -242,7 +242,6 @@ void SphLeapfrogKDK<ndim, ParticleType>::EndTimestep
 //=================================================================================================
 template <int ndim, template <int> class ParticleType>
 int SphLeapfrogKDK<ndim, ParticleType>::CheckTimesteps
-
  (const int level_diff_max,            ///< [in] Max. allowed SPH neib dt diff
   const int level_step,                ///< [in] Level of base timestep
   const int n,                         ///< [in] Integer time in block time struct

--- a/src/MeshlessFV/MeshlessFV.cpp
+++ b/src/MeshlessFV/MeshlessFV.cpp
@@ -445,9 +445,7 @@ int MeshlessFV<ndim>::CheckTimesteps
 (const int level_diff_max,            ///< [in] Max. allowed SPH neib dt diff
  const int level_step,                ///< [in] Level of base timestep
  const int n,                         ///< [in] Integer time in block time struct
- const int Npart,                     ///< [in] Number of particles
  double timestep,                     ///< [in] Timestep
- MeshlessFVParticle<ndim>* mfvdata,
  int mode_)
  {
   int dn;                              // Integer time since beginning of step
@@ -455,6 +453,9 @@ int MeshlessFV<ndim>::CheckTimesteps
   int nnewstep;                        // New integer timestep
   int activecount = 0;                 // No. of newly active particles
   int i;                               // Particle counter
+
+
+  MeshlessFVParticle<ndim> *mfvdata = GetMeshlessFVParticleArray() ;
 
   debug2("[MeshlessFV::CheckTimesteps]");
   CodeTiming::BlockTimer timer = timing->StartNewTimer("MESHLESS_CHECK_TIMESTEPS");
@@ -466,7 +467,7 @@ int MeshlessFV<ndim>::CheckTimesteps
   //-----------------------------------------------------------------------------------------------
   #pragma omp parallel for default(none) private(dn,i,level_new,nnewstep) \
     shared(mfvdata,cout) reduction(+:activecount)
-  for (i=0; i<Npart; i++) {
+  for (i=0; i<Nhydro; i++) {
     MeshlessFVParticle<ndim>& part = mfvdata[i];
     if (part.flags.is_dead()) continue;
 

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -394,6 +394,7 @@ void MeshlessFVSimulation<ndim>::ProcessParameters(void)
   //if (sim == "sph" || sim == "gradhsph" || sim == "sm2012sph" || sim == "godunov_hydro") {
     sinks->timing    = timing;
     mfvneib->SetTimingObject(timing);
+    mfv->timing = timing;
   //}*/
 
 #if defined MPI_PARALLEL
@@ -674,9 +675,6 @@ void MeshlessFVSimulation<ndim>::PostInitialConditionsSetup(void)
 #ifdef MPI_PARALLEL
   MpiGhosts->CopyHydroDataToGhosts(simbox,mfv);
 #endif
-
-  if (time_step_limiter_type == "conservative")
-    mfvneib->UpdateTimestepsLimitsFromDistantParticles(mfv->Nhydro, mfv->Ntot, partdata) ;
 
   if (mfv->self_gravity == 1 || nbody->Nnbody > 0) {
 #ifdef MPI_PARALLEL

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -407,6 +407,8 @@ void MeshlessFVSimulation<ndim>::ProcessParameters(void)
   MpiGhosts = new MpiGhostsSpecific<ndim, MeshlessFVParticle>(mpicontrol);
 #endif
 
+  time_step_limiter_type = stringparams["time_step_limiter"] ;
+
   // Flag that we've processed all parameters already
   ParametersProcessed = true;
 
@@ -673,6 +675,8 @@ void MeshlessFVSimulation<ndim>::PostInitialConditionsSetup(void)
   MpiGhosts->CopyHydroDataToGhosts(simbox,mfv);
 #endif
 
+  if (time_step_limiter_type == "conservative")
+    mfvneib->UpdateTimestepsLimitsFromDistantParticles(mfv->Nhydro, mfv->Ntot, partdata) ;
 
   if (mfv->self_gravity == 1 || nbody->Nnbody > 0) {
 #ifdef MPI_PARALLEL

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -623,7 +623,7 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
     // Loop over all active cells
     //=============================================================================================
 #pragma omp for schedule(guided)
-    for (cc=0; cc<cactive; cc++) {
+    for (int cc=0; cc<cactive; cc++) {
      TreeCellBase<ndim>& cell = celllist[cc];
 
       // Find list of active particles in current cell

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -759,19 +759,6 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
       }
     }
 
-
-#ifdef _OPENMP
-    int Nthreads = omp_get_num_threads() ;
-#else
-    int Nthreads = 1 ;
-#endif
-#pragma omp barrier
-#pragma omp for schedule(static)
-    for(i=0; i<Ntot; ++i) {
-      for (k=0; k < Nthreads; ++k)
-        mfvdata[i].levelneib = max(mfvdata[i].levelneib, levelneibbuf[k][i]) ;
-    }
-
     // Free-up local memory for OpenMP thread
     delete[] rdmdtBuffer;
     delete[] dQBuffer;

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -623,8 +623,8 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
     // Loop over all active cells
     //=============================================================================================
 #pragma omp for schedule(guided)
-    for (int cc=0; cc<cactive; cc++) {
-      TreeCellBase<ndim>& cell = celllist[cc];
+    for (cc=0; cc<cactive; cc++) {
+     TreeCellBase<ndim>& cell = celllist[cc];
 
       // Find list of active particles in current cell
       Nactive = tree->ComputeActiveParticleList(cell,mfvdata,activelist);
@@ -717,17 +717,6 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
           }
         }
         //-----------------------------------------------------------------------------------------
-
-        // Don't do the flux calculation if:
-        //  1) We're going to flag this particle for needing a smaller time-step
-        //  2) All fluxes are provided by neighbours
-        if (level_diff_max > 0 &&
-            (activepart[j].levelneib - activepart[j].level) > level_diff_max) {
-          Nrecalc++;
-          continue;
-        }
-        if (Nhydroaux == 0)
-          continue ;
 
         // Compute all neighbour contributions to hydro fluxes
         mfv->ComputeGodunovFlux(i, Nhydroaux, mfvlist, timestep, activepart[j], neibpart);

--- a/src/MeshlessFV/MfvMusclSimulation.cpp
+++ b/src/MeshlessFV/MfvMusclSimulation.cpp
@@ -108,7 +108,7 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
   nbody->AdvanceParticles(n, nbody->Nnbody, t, timestep, nbody->nbodydata);
 
   // Apply Saitoh & Makino type time-step limiter
-  mfv->CheckTimesteps(level_diff_max, level_step, n, mfv->Nhydro, timestep, partdata, 1);
+  mfv->CheckTimesteps(level_diff_max, level_step, n, timestep, 1);
 
 #ifdef MPI_PARALLEL
   if (Nsteps%ntreebuildstep == 0 || rebuild_tree) {

--- a/src/MeshlessFV/MfvMusclSimulation.cpp
+++ b/src/MeshlessFV/MfvMusclSimulation.cpp
@@ -63,8 +63,14 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
 
   debug2("[MfvMusclSimulation:MainLoop]");
 
-  if (time_step_limiter_type == "conservative")
-    mfvneib->UpdateTimestepsLimitsFromDistantParticles(mfv) ;
+  if (time_step_limiter_type == "conservative") {
+    mfvneib->UpdateTimestepsLimitsFromDistantParticles(mfv,false);
+#ifdef MPI_PARALLEL
+    mpicontrol->ExportParticlesBeforeForceLoop(mfv);
+    mfvneib->UpdateTimestepsLimitsFromDistantParticles(mfv,true);
+    mpicontrol->GetExportedParticlesAccelerations(mfv);
+#endif
+  }
 
   // Compute timesteps for all particles
   if (Nlevels == 1) {

--- a/src/MeshlessFV/MfvMusclSimulation.cpp
+++ b/src/MeshlessFV/MfvMusclSimulation.cpp
@@ -266,6 +266,10 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
   //   Compute gradients for all cells neighbouring active ones (use levelneib?).
   mfvneib->UpdateGradientMatrices(mfv, nbody, simbox);
 
+  if (time_step_limiter_type == "conservative")
+    mfvneib->UpdateTimestepsLimitsFromDistantParticles(mfv->Nhydro, mfv->Ntot, partdata) ;
+
+
   /* Check that we have sensible smoothing lengths */
   if (periodicBoundaries) {
     double hmax = mfvneib->GetMaximumSmoothingLength() ;

--- a/src/MeshlessFV/MfvMusclSimulation.cpp
+++ b/src/MeshlessFV/MfvMusclSimulation.cpp
@@ -64,7 +64,7 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
   debug2("[MfvMusclSimulation:MainLoop]");
 
   if (time_step_limiter_type == "conservative")
-    mfvneib->UpdateTimestepsLimitsFromDistantParticles(mfv->Nhydro, mfv->Ntot, partdata) ;
+    mfvneib->UpdateTimestepsLimitsFromDistantParticles(mfv) ;
 
   // Compute timesteps for all particles
   if (Nlevels == 1) {

--- a/src/Tree/BruteForceTree.cpp
+++ b/src/Tree/BruteForceTree.cpp
@@ -54,9 +54,10 @@ BruteForceTree<ndim,ParticleType,TreeCell>::BruteForceTree(int Nleafmaxaux, FLOA
                                            	   	   	   	   FLOAT kernrangeaux, FLOAT macerroraux,
                                            	   	   	   	   string gravity_mac_aux, string multipole_aux,
                                            	   	   	   	   const DomainBox<ndim>& domain,
-                                           	   	   	   	   const ParticleTypeRegister& reg):
+                                           	   	   	   	   const ParticleTypeRegister& reg,
+														   const bool IAmPruned):
   Tree<ndim,ParticleType,TreeCell>(Nleafmaxaux, thetamaxsqdaux, kernrangeaux,
-                                   macerroraux, gravity_mac_aux, multipole_aux, domain, reg)
+                                   macerroraux, gravity_mac_aux, multipole_aux, domain, reg,IAmPruned)
 {
   allocated_tree = false;
   gmax           = 0;

--- a/src/Tree/BruteForceTree.cpp
+++ b/src/Tree/BruteForceTree.cpp
@@ -346,6 +346,7 @@ void BruteForceTree<ndim,ParticleType,TreeCell>::StockTreeProperties
   cell.drmaxdt  = (FLOAT) 0.0;
   cell.mac      = (FLOAT) 0.0;
   cell.cdistsqd = big_number;
+  cell.maxsound = (FLOAT) 0.0;
   for (k=0; k<5; k++) cell.q[k]          = (FLOAT) 0.0;
   for (k=0; k<ndim; k++) cell.r[k]       = (FLOAT) 0.0;
   for (k=0; k<ndim; k++) cell.v[k]       = (FLOAT) 0.0;
@@ -382,6 +383,7 @@ void BruteForceTree<ndim,ParticleType,TreeCell>::StockTreeProperties
 	  cell.N++;
 	  if (partdata[i].flags.check_flag(active)) cell.Nactive++;
 	  cell.hmax = max(cell.hmax,partdata[i].h);
+	  cell.maxsound = max(cell.maxsound, partdata[i].sound);
 	  if (gravmask[partdata[i].ptype]) {
 		cell.m += partdata[i].m;
 		for (k=0; k<ndim; k++) cell.r[k] += partdata[i].m*partdata[i].r[k];
@@ -394,6 +396,8 @@ void BruteForceTree<ndim,ParticleType,TreeCell>::StockTreeProperties
 			cell.hbox.min[k] = partdata[i].r[k] - kernrange*partdata[i].h;
 		if 	(partdata[i].r[k] + kernrange*partdata[i].h > cell.hbox.max[k])
 			cell.hbox.max[k] = partdata[i].r[k] + kernrange*partdata[i].h;
+		if (partdata[i].v[k] > cell.vbox.max[k]) cell.vbox.max[k] = partdata[i].v[k];
+		if (partdata[i].v[k] < cell.vbox.min[k]) cell.vbox.min[k] = partdata[i].v[k];
 	  }
 	}
 	if (i == cell.ilast) break;

--- a/src/Tree/HydroTree.cpp
+++ b/src/Tree/HydroTree.cpp
@@ -649,13 +649,11 @@ double HydroTree<ndim,ParticleType>::GetMaximumSmoothingLength() const
 
 template <int ndim, template <int> class ParticleType>
 void HydroTree<ndim,ParticleType>::UpdateTimestepsLimitsFromDistantParticles
-(int Nhydro,                                      ///< [in] No. of hydro particles
- int Ntot,                                        ///< [in] No. of hydro + ghost particles
- Particle<ndim> *part_gen)                        ///< [inout] Pointer to Hydrodynamics ptcl array
+(Hydrodynamics<ndim>* hydro)                     ///<[inout] Pointer to Hydrodynamics object
  {
   int cactive;                          // No. of active cells
   vector<TreeCellBase<ndim> > celllist; // List of active tree cells
-  ParticleType<ndim>* partdata = static_cast<ParticleType<ndim>* > (part_gen);
+  ParticleType<ndim>* partdata = static_cast<ParticleType<ndim>* > (hydro->GetParticleArray());
 
   debug2("[HydroTree::UpdateTimestepsLimitsFromDistantParticles]");
   CodeTiming::BlockTimer timer = timing->StartNewTimer("HYDRO_DISTANT_TIMESTEPS");

--- a/src/Tree/HydroTree.cpp
+++ b/src/Tree/HydroTree.cpp
@@ -718,8 +718,6 @@ void HydroTree<ndim,ParticleType>::UpdateTimestepsLimitsFromDistantParticles
       if (!only_imported_particles) {
 		  // Loop over pruned trees as well
 		  // Doing it after the local tree walk is more efficient as vsig_max might have been already increased
-		  // TODO: is it more efficient to have this loop inside or outside the one over particles? In this way we are trashing
-		  // the cache of the pruned tree. We should probably swap them. Need to think carefully about openMP though
 		  for (int i=0; i<Nmpi; i++) {
 			  if (i==rank) continue;
 

--- a/src/Tree/KDTree.cpp
+++ b/src/Tree/KDTree.cpp
@@ -52,9 +52,10 @@ KDTree<ndim,ParticleType,TreeCell>::KDTree(int Nleafmaxaux, FLOAT thetamaxsqdaux
                                            FLOAT kernrangeaux, FLOAT macerroraux,
                                            string gravity_mac_aux, string multipole_aux,
                                            const DomainBox<ndim>& domain,
-                                  		   const ParticleTypeRegister& reg):
+                                  		   const ParticleTypeRegister& reg,
+										   const bool IAmPruned):
   Tree<ndim,ParticleType,TreeCell>(Nleafmaxaux, thetamaxsqdaux, kernrangeaux,
-                                   macerroraux, gravity_mac_aux, multipole_aux, domain, reg)
+                                   macerroraux, gravity_mac_aux, multipole_aux, domain, reg, IAmPruned)
 {
   allocated_tree = false;
   gmax           = 0;
@@ -822,6 +823,7 @@ void KDTree<ndim,ParticleType,TreeCell>::StockCellProperties
   cell.drmaxdt  = (FLOAT) 0.0;
   cell.mac      = (FLOAT) 0.0;
   cell.cdistsqd = big_number;
+  cell.maxsound = (FLOAT) 0.0;
   for (k=0; k<5; k++) cell.q[k]          = (FLOAT) 0.0;
   for (k=0; k<ndim; k++) cell.r[k]       = (FLOAT) 0.0;
   for (k=0; k<ndim; k++) cell.v[k]       = (FLOAT) 0.0;

--- a/src/Tree/KDTree.cpp
+++ b/src/Tree/KDTree.cpp
@@ -863,6 +863,7 @@ void KDTree<ndim,ParticleType,TreeCell>::StockCellProperties
         cell.N++;
         if (partdata[i].flags.check_flag(active)) cell.Nactive++;
         cell.hmax = max(cell.hmax,partdata[i].h);
+        cell.maxsound = max(cell.maxsound, partdata[i].sound);
         if (gravmask[partdata[i].ptype]) {
           cell.m += partdata[i].m;
           for (k=0; k<ndim; k++) cell.r[k] += partdata[i].m*partdata[i].r[k];
@@ -875,6 +876,8 @@ void KDTree<ndim,ParticleType,TreeCell>::StockCellProperties
          cell.hbox.min[k] = partdata[i].r[k] - kernrange*partdata[i].h;
          if (partdata[i].r[k] + kernrange*partdata[i].h > cell.hbox.max[k])
           cell.hbox.max[k] = partdata[i].r[k] + kernrange*partdata[i].h;
+         if (partdata[i].v[k] > cell.vbox.max[k]) cell.vbox.max[k] = partdata[i].v[k];
+         if (partdata[i].v[k] < cell.vbox.min[k]) cell.vbox.min[k] = partdata[i].v[k];
         }
       }
       if (i == cell.ilast) break;
@@ -934,14 +937,20 @@ void KDTree<ndim,ParticleType,TreeCell>::StockCellProperties
       for (k=0; k<ndim; k++) cell.bb.max[k] = max(child1.bb.max[k],cell.bb.max[k]);
       for (k=0; k<ndim; k++) cell.hbox.min[k] = min(child1.hbox.min[k],cell.hbox.min[k]);
       for (k=0; k<ndim; k++) cell.hbox.max[k] = max(child1.hbox.max[k],cell.hbox.max[k]);
+      for (k=0; k<ndim; k++) cell.vbox.min[k] = min(child1.vbox.min[k],cell.vbox.min[k]);
+      for (k=0; k<ndim; k++) cell.vbox.max[k] = max(child1.vbox.max[k],cell.vbox.max[k]);
       cell.hmax = max(cell.hmax,child1.hmax);
+      cell.maxsound = max(cell.maxsound,child1.maxsound);
     }
     if (child2.N > 0) {
       for (k=0; k<ndim; k++) cell.bb.min[k] = min(child2.bb.min[k],cell.bb.min[k]);
       for (k=0; k<ndim; k++) cell.bb.max[k] = max(child2.bb.max[k],cell.bb.max[k]);
       for (k=0; k<ndim; k++) cell.hbox.min[k] = min(child2.hbox.min[k],cell.hbox.min[k]);
       for (k=0; k<ndim; k++) cell.hbox.max[k] = max(child2.hbox.max[k],cell.hbox.max[k]);
+      for (k=0; k<ndim; k++) cell.vbox.min[k] = min(child2.vbox.min[k],cell.vbox.min[k]);
+      for (k=0; k<ndim; k++) cell.vbox.max[k] = max(child2.vbox.max[k],cell.vbox.max[k]);
       cell.hmax = max(cell.hmax,child2.hmax);
+      cell.maxsound = max(cell.maxsound,child2.maxsound);
     }
 
     cell.N = child1.N + child2.N;

--- a/src/Tree/OctTree.cpp
+++ b/src/Tree/OctTree.cpp
@@ -528,6 +528,7 @@ void OctTree<ndim,ParticleType,TreeCell>::StockTree
             cell.N++;
             if (partdata[i].flags.check_flag(active)) cell.Nactive++;
             cell.hmax = max(cell.hmax, partdata[i].h);
+            cell.maxsound = max(cell.maxsound, partdata[i].sound);
             if (gravmask[partdata[i].ptype]) {
               cell.m += partdata[i].m;
               for (k=0; k<ndim; k++) cell.r[k] += partdata[i].m*partdata[i].r[k];
@@ -540,6 +541,8 @@ void OctTree<ndim,ParticleType,TreeCell>::StockTree
                 cell.hbox.min[k] = partdata[i].r[k] - kernrange*partdata[i].h;
               if (partdata[i].r[k] + kernrange*partdata[i].h > cell.hbox.max[k])
                 cell.hbox.max[k] = partdata[i].r[k] + kernrange*partdata[i].h;
+              if (partdata[i].v[k] > cell.vbox.max[k]) cell.vbox.max[k] = partdata[i].v[k];
+              if (partdata[i].v[k] < cell.vbox.min[k]) cell.vbox.min[k] = partdata[i].v[k];
             }
           }
           if (i == cell.ilast) break;
@@ -603,9 +606,12 @@ void OctTree<ndim,ParticleType,TreeCell>::StockTree
             for (k=0; k<ndim; k++) cell.bb.max[k]   = max(child.bb.max[k], cell.bb.max[k]);
             for (k=0; k<ndim; k++) cell.hbox.min[k] = min(child.hbox.min[k], cell.hbox.min[k]);
             for (k=0; k<ndim; k++) cell.hbox.max[k] = max(child.hbox.max[k], cell.hbox.max[k]);
+            for (k=0; k<ndim; k++) cell.vbox.min[k] = min(child.vbox.min[k],cell.vbox.min[k]);
+            for (k=0; k<ndim; k++) cell.vbox.max[k] = max(child.vbox.max[k],cell.vbox.max[k]);
             for (k=0; k<ndim; k++) cell.r[k] += child.m*child.r[k];
             for (k=0; k<ndim; k++) cell.v[k] += child.m*child.v[k];
             cell.hmax = max(child.hmax, cell.hmax);
+            cell.maxsound = max(cell.maxsound,child.maxsound);
             cell.m += child.m;
             cell.N += child.N;
           }

--- a/src/Tree/OctTree.cpp
+++ b/src/Tree/OctTree.cpp
@@ -50,9 +50,10 @@ OctTree<ndim,ParticleType,TreeCell>::OctTree(int Nleafmaxaux, FLOAT thetamaxsqda
                                              FLOAT kernrangeaux, FLOAT macerroraux,
                                              string gravity_mac_aux, string multipole_aux,
                                              const DomainBox<ndim>& domain,
-                                    		 const ParticleTypeRegister& reg) :
+                                    		 const ParticleTypeRegister& reg,
+											 const bool IAmPruned) :
   Tree<ndim,ParticleType,TreeCell>(Nleafmaxaux, thetamaxsqdaux, kernrangeaux,
-                                   macerroraux, gravity_mac_aux, multipole_aux, domain, reg)
+                                   macerroraux, gravity_mac_aux, multipole_aux, domain, reg,IAmPruned)
 {
   allocated_tree = false;
   ifirst         = -1;
@@ -488,6 +489,7 @@ void OctTree<ndim,ParticleType,TreeCell>::StockTree
       cell.drmaxdt  = (FLOAT) 0.0;
       cell.mac      = (FLOAT) 0.0;
       cell.cdistsqd = big_number;
+      cell.maxsound = (FLOAT) 0.0;
       for (k=0; k<ndim; k++) cell.r[k]       = (FLOAT) 0.0;
       for (k=0; k<ndim; k++) cell.v[k]       = (FLOAT) 0.0;
       for (k=0; k<ndim; k++) cell.rcell[k]   = (FLOAT) 0.0;

--- a/src/Tree/Tree.cpp
+++ b/src/Tree/Tree.cpp
@@ -971,6 +971,16 @@ int Tree<ndim,ParticleType,TreeCell>::ComputeStarGravityInteractionList
   return 1;
 }
 
+//=================================================================================================
+//  Tree::ComputeSignalVelocityFromDistantInteractions
+/// Computes an effective signal velocity from distant interactions in order to ensure that the
+/// timesteps used are small enough to detect approaching shocks. It does this for each of the
+/// active particles included in a list by walking the tree and opening the cells if:
+///   1) They overlap
+///   2) dt * ( cs_1 + cs_2 - Delta v) > Delta r.
+/// The time-step used in the tree walk is continually updated to use to most stringent condition
+/// for opening the tree cells.
+//=================================================================================================
 template <int ndim, template<int> class ParticleType, template<int> class TreeCell>
 void Tree<ndim,ParticleType,TreeCell>::ComputeSignalVelocityFromDistantInteractions
 (const TreeCellBase<ndim>& cell,                       ///< [in] Pointer to cell

--- a/src/Tree/Tree.cpp
+++ b/src/Tree/Tree.cpp
@@ -583,7 +583,6 @@ int Tree<ndim,ParticleType,TreeCell>::ComputeNeighbourAndGhostList
 
     int Nmax = NumGhosts + Nneib;
     while (Nneib < Nmax) {
-      //neibpart[Nneib].iorig = i;
       for (k=0; k<ndim; k++) dr[k] = neibpart[Nneib].r[k] - rc[k];
       drsqd = DotProduct(dr, dr, ndim);
       FLOAT h2 = rmax + kernrange*neibpart[Nneib].h;
@@ -970,6 +969,142 @@ int Tree<ndim,ParticleType,TreeCell>::ComputeStarGravityInteractionList
   assert(VerifyUniqueIds(Nneib, Ntot, neiblist));
 
   return 1;
+}
+
+template <int ndim, template<int> class ParticleType, template<int> class TreeCell>
+void Tree<ndim,ParticleType,TreeCell>::ComputeSignalVelocityFromDistantInteractions
+(const TreeCellBase<ndim>& cell,                       ///< [in] Pointer to cell
+ int Nactive,
+ Particle<ndim>* active_gen,
+ Particle<ndim>* part_gen)
+{
+  ParticleType<ndim> *activepart = reinterpret_cast<ParticleType<ndim>*>(active_gen);
+  ParticleType<ndim> *partdata = reinterpret_cast<ParticleType<ndim>*>(part_gen);
+
+  FLOAT rcell[ndim] ;
+  FLOAT half[ndim] ;
+  for (int k=0; k<ndim; k++) rcell[k] = 0.5 * (cell.bb.max[k] + cell.bb.min[k]) ;
+  for (int k=0; k<ndim; k++) half[k]  = 0.5 * (cell.bb.max[k] - cell.bb.min[k]) ;
+
+  const GhostNeighbourFinder<ndim> GhostFinder(_domain, cell) ;
+  const int MaxNumGhosts = GhostFinder.MaxNumGhosts() ;
+
+  // Make an initial guess of the minimum time-step
+  FLOAT dt_min = 0;
+  for(int n=0; n < Nactive; n++) {
+    ParticleType<ndim>& part = activepart[n] ;
+    if (part.vsig_max > 0)
+      dt_min = max(dt_min, part.h / part.vsig_max) ;
+    else
+      dt_min = big_number ;
+  }
+
+  // Walk the tree
+  int cc = 0;                          // Cell counter (start at root cell)
+  int k;
+  //===============================================================================================
+  while (cc < Ncell) {
+    TreeCell<ndim>& other = celldata[cc];
+
+    // Compute the distance between two cells and their combined size
+    FLOAT dr[ndim] ;
+    for (k=0; k<ndim; k++)
+      dr[k] = 0.5*(other.bb.max[k] + other.bb.min[k]) - rcell[k] ;
+
+    GhostFinder.NearestPeriodicVector(dr) ;
+
+    FLOAT width[ndim] ;
+    for (k=0; k<ndim; k++) width[k] = half[k] + 0.5 * (other.bb.max[k] - other.bb.min[k]) ;
+
+    // If there is overlap, open the cell
+    bool open = true ;
+    for (k=0; k<ndim; k++) open &= width[k] > fabs(dr[k]) ;
+
+    // Also open the cell if waves can interact within dt_min
+    if (!open) {
+      // Compute the minimum distance between the cells and the dvdr
+      FLOAT dvdr = 0 ;
+      FLOAT rmin = 0 ;
+      for(k=0; k<ndim; k++) {
+        if (dr[k] > 0) {
+          FLOAT drk = dr[k] - width[k] ;
+          rmin += drk*drk ;
+
+          dvdr += drk * (other.vbox.min[k] - cell.vbox.max[k]) ;
+        }
+        else {
+          FLOAT drk = dr[k] + width[k] ;
+          rmin += drk*drk ;
+
+          dvdr += drk * (other.vbox.max[k] - cell.vbox.min[k]) ;
+        }
+      }
+      rmin  = sqrt(rmin) ;
+      dvdr /= rmin + small_number ;
+
+      FLOAT vsig = cell.maxsound + other.maxsound - dvdr ;
+
+      if (dt_min * vsig > rmin)
+        open = true ;
+    }
+
+    if (open) {
+      // If not a leaf cell, open it.
+      if (celldata[cc].copen != -1) {
+        cc = celldata[cc].copen;
+        continue ;
+      }
+
+      // Ignore any empty cells
+      if (celldata[cc].N == 0) {
+        cc = celldata[cc].cnext;
+        continue ;
+      }
+
+      // Leaf cell so update vsig_max for each particle
+      int i = celldata[cc].ifirst;
+      while (i != -1) {
+        std::vector<ParticleType<ndim> > neibpart(MaxNumGhosts) ;
+        int NumGhosts = GhostFinder.ConstructAllGhosts(partdata[i], &(neibpart[0]));
+
+        for (int j=0; j<Nactive; j++) {
+          ParticleType<ndim>& part = activepart[j] ;
+
+          for (int l=0; l<NumGhosts; l++) {
+            double dvdr = 0 ;
+            double dr = 0 ;
+            for (k=0; k<ndim; k++)  {
+              double drk = part.r[k] - neibpart[l].r[k] ;
+              dvdr += drk * (part.v[k] - neibpart[l].v[k]);
+              dr += drk*drk ;
+            }
+            if (dr > 0) {
+              dr = sqrt(dr) ;
+              dvdr /= dr + small_number ;
+
+              FLOAT vsig = part.sound + neibpart[l].sound - dvdr ;
+              part.vsig_max = max(part.vsig_max, vsig*part.h/dr) ;
+              assert(part.vsig_max >= 0) ;
+            }
+          }
+        }
+        if (i == celldata[cc].ilast) break;
+        i = inext[i];
+      }
+
+      // Construct the new guess for dt_min
+      dt_min = 0 ;
+      for(int n=0; n < Nactive; n++) {
+        ParticleType<ndim>& part = activepart[n] ;
+        if (part.vsig_max > 0)
+          dt_min = max(dt_min, part.h / part.vsig_max) ;
+        else
+          dt_min = big_number ;
+      }
+    }
+
+    cc = celldata[cc].cnext;
+  }
 }
 
 

--- a/tests/hydro_tests/sedov_meshless.dat
+++ b/tests/hydro_tests/sedov_meshless.dat
@@ -1,0 +1,101 @@
+#--------------------------------------------------------------
+# Sedov Blast Wave test
+# Creates Sedov blast wave test
+#--------------------------------------------------------------
+
+
+#-----------------------------
+# Initial conditions variables
+#-----------------------------
+Simulation run id string                    : run_id = SEDOV-MFM
+Select SPH simulation                       : sim = mfvmuscl
+Select shocktube initial conditions         : ic = sedov
+Dimensionality of cube                      : ndim = 2
+Pressure of fluid 1                         : press1 = 1.0
+Density of fluid 1                          : rhofluid1 = 1.0
+No. of x-particles in fluid 1               : Nlattice1[0] = 64
+No. of y-particles in fluid 1               : Nlattice1[1] = 64
+No. of y-particles in fluid 1               : Nlattice1[2] = 64
+Local arrangement of particles              : particle_distribution = cubic_lattice
+Use dimensionless units                     : dimensionless = 1
+
+
+#------------------------------
+# Simulation boundary variables
+#------------------------------
+LHS position of boundary in x-dimension     : boxmin[0] = -1.0
+RHS position of boundary in x-dimension     : boxmax[0] = 1.0
+LHS position of boundary in y-dimension     : boxmin[1] = -1.0
+RHS position of boundary in y-dimension     : boxmax[1] = 1.0
+LHS position of boundary in z-dimension     : boxmin[2] = -1.0
+RHS position of boundary in z-dimension     : boxmax[2] = 1.0
+LHS boundary type in x-dimension            : boundary_lhs[0] = periodic
+RHS boundary type in x-dimension            : boundary_rhs[0] = periodic
+LHS boundary type in y-dimension            : boundary_lhs[1] = periodic
+RHS boundary type in y-dimension            : boundary_rhs[1] = periodic
+LHS boundary type in z-dimension            : boundary_lhs[2] = periodic
+RHS boundary type in z-dimension            : boundary_rhs[2] = periodic
+
+
+#--------------------------
+# Simulation time variables
+#--------------------------
+Simulation end time                         : tend = 0.6
+Time for first snapshot                     : tsnapfirst = 0.0
+Regular snapshot output frequency           : dt_snap = 0.1
+Screen output frequency (in no. of steps)   : noutputstep = 128
+
+
+#------------------------
+# Thermal physics options
+#------------------------
+Switch-on hydrodynamical forces             : hydro_forces = 1
+Main gas thermal physics treatment          : gas_eos = energy_eqn
+Ratio of specific heats of gas              : gamma_eos = 1.66666666666666666
+
+
+#----------------------------------------
+# Smoothed Particle Hydrodynamics options
+#----------------------------------------
+SPH algorithm choice                        : sph = gradh
+SPH smoothing kernel choice                 : kernel = m4
+SPH smoothing length iteration tolerance    : h_converge = 0.001
+    	      	     	       		    : h_fac = 1.13
+
+
+#---------------------------------
+# SPH artificial viscosity options
+#---------------------------------
+Artificial viscosity choice                 : avisc = mon97
+Artificial conductivity choice              : acond = none
+Artificial viscosity alpha value            : alpha_visc = 1.0
+Artificial viscosity beta value             : beta_visc = 2.0
+	   	     	  		    : riemann_solver = hllc
+					    : slope_limiter = gizmo
+					    : zero_mass_flux = 1
+					    : time_step_limiter = conservative
+
+
+#-------------------------
+# Time integration options
+#-------------------------
+SPH particle integration option             : sph_integration = lfkdk
+SPH Courant timestep condition multiplier   : courant_mult = 0.1
+SPH acceleration condition multiplier       : accel_mult = 0.2
+SPH energy equation timestep multiplier     : energy_mult = 0.3
+No. of block timestep levels                : Nlevels = 10
+Maximum timestep level difference           : level_diff_max = 1
+
+
+#---------------------
+# Optimisation options
+#---------------------
+Tabulate SPH kernel                         : tabulated_kernel = 1
+SPH neighbour search algorithm              : neib_search = kdtree
+No. of particles per leaf cell              : Nleafmax = 6
+
+
+#--------------
+# Misc. options
+#--------------
+Switch-off self-gravity of gas              : self_gravity = 0


### PR DESCRIPTION
I'm beginning this pull request to spark discussion, rather than because it is ready to merge. It contains two methods to limit the timesteps:
- 1) A fully conservative and predicive one based on a tree walk 
- 2) A non-conservative Saitoh & Makino type limiter adjusting the timestep in a post-hoc way.

The first one works by finding the largest dt such that  r_ij \* vsig_ij > dt for all pair in the simulation. This is done in an extra tree walk, which will need making MPI compatible later.

The second one just checks for particles that have too big timesteps compared to their neighbours and reduces their timestep at the next synchronization point. It is not exactly conservative since dQdt is used to predict dQ, but it seems to work fine for the sedov test.

In doing this work, I noticed that we don't enforce the levelneib heirachy properly at the moment. While the issue of reducing the time-step particles in the middle of their step conservatively is near impossible (although limiter 2 does is this in a non-conservative way). However, in addition we don't enforce the hierarchy at the start of the timestep either, which I think is a significant flaw. The reason that the heirachy is not enforced is that levelneib is computed before the new timesteps are evaluated, and after the new timesteps are calculated the levels shift, leading to some particles needing a smaller timestep than the one they are on because some of their neighbours are now on smaller timesteps.

I  think that enforcing the hierarchy would improve the results when no extra timestep limiters are used or when the non-conservative limiters are used. This is because the fluxes are computed at the start of the timestep. Thus if we can predict that we are going to need a smaller timestep at the beginning of it we can reduce it immediately allowing a fully conservative update of these particles. With the global limiter switched on fewer particles tend to have level differences greater than requested, but some still do.  

In SPH we enforce the hierarchy by iterating the whole timestep for particles on levels that are too big, but this is difficult to do correctly for the meshless because tracking the update of dQ is difficult. I have included an attemp at this by iterating on only the flux calculation but it doesn't work properly. I believe it would be much easier to iterate on the gradient calculation until the timesteps are set properly, but currently the gradients are done before the timestep calcution. Placing it after the timestep calculation has the issue that levelneib is not known in advance since we calculate it during the gradient calculation. 

I would think that the most effective solution would be as follows: 1) Compute a gather based estimate of levelneib during the density calculation. 2) Compute the new timesteps. 3) Compute the full levelneib during the gradient calculation. To do this we would need to iterate on particles that had their timestep reduced to ensure it is propograted to all its neighbours. Step 3) could also be done in another tree walk to avoid recomputing the gradients.

The questions I have are as follows: How important do you think this is? Should we expend the extra cycles (probably only a few to 10 per cent) on making it more accurate? How should we implement it? I believe before the flux calculation is the only reasonable way.
