### PR TITLE
Stock pruned

### DIFF
--- a/src/GradhSph/GradhSph.cpp
+++ b/src/GradhSph/GradhSph.cpp
@@ -256,7 +256,7 @@ int GradhSph<ndim, kernelclass>::ComputeH
 
     // Density must at least equal its self-contribution
     // (failure could indicate neighbour list problem)
-    assert(parti.rho >= parti.m*parti.hfactor*kern.w0(0.0));
+    assert(parti.rho >= parti.m*parti.hfactor*kern.w0_s2(0.0));
 
     FLOAT invrho = 0 ;
     if (parti.rho > (FLOAT) 0.0) invrho = (FLOAT) 1.0/parti.rho;
@@ -479,7 +479,10 @@ void GradhSph<ndim, kernelclass>::ComputeSphHydroForces
     //---------------------------------------------------------------------------------------------
 
     // Add total hydro contribution to acceleration for particle i
-    for (k=0; k<ndim; k++) parti.a[k] += neibpart[j].m*draux[k]*paux;
+    for (k=0; k<ndim; k++) {
+    	parti.a[k] += neibpart[j].m*draux[k]*paux;
+    	assert(parti.a[k]==parti.a[k]);
+    }
     parti.levelneib = max(parti.levelneib,neibpart[j].level);
 
   }

--- a/src/GradhSph/GradhSphTree.cpp
+++ b/src/GradhSph/GradhSphTree.cpp
@@ -332,11 +332,6 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphHydroForces
     return;
   }
 
-  // Update ghost tree smoothing length values here
-  tree->UpdateAllHmaxValues(sphdata);
-  //if (ghosttree->Ntot > 0) ghosttree->UpdateHmaxValues(ghosttree->celldata[0],sphdata);
-
-
   // Set-up all OMP threads
   //===============================================================================================
 #pragma omp parallel default(none) shared(cactive,celllist,nbody,simbox,sph,sphdata)

--- a/src/Headers/BruteForceTree.h
+++ b/src/Headers/BruteForceTree.h
@@ -109,11 +109,11 @@ class BruteForceTree : public Tree<ndim,ParticleType,TreeCell>
   void AllocateTreeMemory(int,int,bool);
   void ReallocateMemory(int,int);
   void DeallocateTreeMemory(void);
-  void StockTree(Particle<ndim> *part_gen) {
+  void StockTree(Particle<ndim> *part_gen, bool stock_leaf) {
     ParticleType<ndim>* partdata = reinterpret_cast<ParticleType<ndim>*>(part_gen) ;
-    StockTree(celldata[0], partdata) ;
+    StockTree(celldata[0], partdata, stock_leaf) ;
   }
-  void StockTree(TreeCell<ndim>&, ParticleType<ndim> *);
+  void StockTree(TreeCell<ndim>&, ParticleType<ndim> *, bool stock_leaf);
   void StockTreeProperties(TreeCell<ndim> &, ParticleType<ndim> *);
   void UpdateAllHmaxValues(Particle<ndim> *part_gen) {
     ParticleType<ndim>* partdata = reinterpret_cast<ParticleType<ndim>*>(part_gen) ;

--- a/src/Headers/InlineFuncs.h
+++ b/src/Headers/InlineFuncs.h
@@ -418,55 +418,6 @@ static inline bool BoxOverlap
 /// Returns what fraction of box 1 overlaps box 2
 //=================================================================================================
 static inline FLOAT FractionalBoxOverlap
- (const int ndim,
-  FLOAT *box1min,                      ///< Minimum extent of box 1
-  FLOAT *box1max,                      ///< Maximum extent of box 1
-  FLOAT *box2min,                      ///< Minimum extent of box 2
-  FLOAT *box2max)                      ///< Maximum extent of box 2
-{
-  int k;                             // ..
-  FLOAT area    = (FLOAT) 1.0;       // ..
-  FLOAT overlap = (FLOAT) 1.0;       // ..
-  FLOAT frac    = (FLOAT) 0.0;       // ..
-
-  for (k=0; k<ndim; k++) assert(box1min[k] < box1max[k]);
-  for (k=0; k<ndim; k++) assert(box2min[k] < box2max[k]);
-
-  for (k=0; k<ndim; k++) {
-    area *= (box1max[k] - box1min[k]);
-    if (box1max[k] <= box2min[k] || box1min[k] >= box2max[k]) {
-      overlap *= (FLOAT) 0.0;
-    }
-    else if (box1min[k] > box2min[k] && box1max[k] < box2max[k]) {
-      overlap *= (box1max[k] - box1min[k]);
-    }
-    else if (box1min[k] < box2min[k] && box1max[k] > box2max[k]) {
-      overlap *= (box2max[k] - box2min[k]);
-    }
-    else if (box1min[k] < box2min[k] && box1max[k] < box2max[k]) {
-      overlap *= (box1max[k] - box2min[k]);
-    }
-    else if (box1min[k] > box2min[k] && box1max[k] > box2max[k]) {
-      overlap *= (box2max[k] - box1min[k]);
-    }
-    else {
-      cout << "Should never get here!! " << overlap << "    area : " << area << endl;
-    }
-  }
-
-  if (area > 0.0) frac = overlap/area;
-  assert(frac >= 0.0 && frac <= 1.0);
-
-  return frac;
-}
-
-
-
-//=================================================================================================
-//  FractionalBoxOverlap
-/// Returns what fraction of box 1 overlaps box 2
-//=================================================================================================
-static inline FLOAT FractionalBoxOverlap
  (const int ndim,                      ///< Dimensionality
   const FLOAT *box2min,                ///< Minimum extent of box 1
   const FLOAT *box2max,                ///< Maximum extent of box 1

--- a/src/Headers/KDRadiationTree.h
+++ b/src/Headers/KDRadiationTree.h
@@ -129,8 +129,8 @@ class KDRadiationTree
   int FindRayExitFace(CellType<ndim,nfreq> &, const FLOAT *, const FLOAT *, const FLOAT *, FLOAT &);
   void OptimiseTree(void);
   FLOAT QuickSelect(int, int, int, int, ParticleType<ndim> *);
-  void StockTree(CellType<ndim,nfreq> &, ParticleType<ndim> *);
-  void StockCellProperties(CellType<ndim,nfreq> &, ParticleType<ndim> *);
+  void StockTree(CellType<ndim,nfreq> &, ParticleType<ndim> *, bool);
+  void StockCellProperties(CellType<ndim,nfreq> &, ParticleType<ndim> *, bool);
   void SumRadiationField(const int, CellType<ndim,nfreq> &);
 
 

--- a/src/Headers/KDTree.h
+++ b/src/Headers/KDTree.h
@@ -126,12 +126,12 @@ class KDTree : public Tree<ndim,ParticleType,TreeCell>
   void ExtrapolateCellProperties(const FLOAT);
   FLOAT QuickSelect(int, int, int, int, ParticleType<ndim> *);
   FLOAT QuickSelectSort(int, int, int, int, ParticleType<ndim> *);
-  void StockTree(Particle<ndim> *part_gen) {
+  void StockTree(Particle<ndim> *part_gen, bool stock_leaf) {
     ParticleType<ndim>* partdata = reinterpret_cast<ParticleType<ndim>*>(part_gen) ;
-    StockTree(celldata[0], partdata) ;
+    StockTree(celldata[0], partdata, stock_leaf) ;
   }
-  void StockTree(TreeCell<ndim>&, ParticleType<ndim> *);
-  void StockCellProperties(TreeCell<ndim> &, ParticleType<ndim> *);
+  void StockTree(TreeCell<ndim>&, ParticleType<ndim> *, bool);
+  void StockCellProperties(TreeCell<ndim> &, ParticleType<ndim> *,bool);
   void UpdateAllHmaxValues(Particle<ndim> *part_gen) {
     ParticleType<ndim>* partdata = reinterpret_cast<ParticleType<ndim>*>(part_gen) ;
     UpdateHmaxValues(celldata[0], partdata) ;

--- a/src/Headers/NeighbourSearch.h
+++ b/src/Headers/NeighbourSearch.h
@@ -177,6 +177,7 @@ protected:
 
   virtual void BuildPrunedTree(const int, const DomainBox<ndim> &,
                                const MpiNode<ndim> *, Hydrodynamics<ndim> *);
+  virtual void StockPrunedTree(const int rank,Hydrodynamics<ndim>* hydro);
   virtual void BuildMpiGhostTree(const bool, const int, const int, const int,
                                  const FLOAT, Hydrodynamics<ndim> *);
   virtual FLOAT FindLoadBalancingDivision(int, FLOAT, FLOAT *, FLOAT *);

--- a/src/Headers/NeighbourSearch.h
+++ b/src/Headers/NeighbourSearch.h
@@ -96,6 +96,7 @@ protected:
 
   virtual void BuildPrunedTree(const int, const DomainBox<ndim> &,
                                const MpiNode<ndim> *, Hydrodynamics<ndim> *) = 0;
+  virtual void StockPrunedTree(const int rank,Hydrodynamics<ndim>* hydro) = 0;
   virtual void BuildMpiGhostTree(const bool, const int, const int, const int,
                                  const FLOAT, Hydrodynamics<ndim> *) = 0;
   virtual FLOAT FindLoadBalancingDivision(int, FLOAT, FLOAT *, FLOAT *) = 0;

--- a/src/Headers/OctTree.h
+++ b/src/Headers/OctTree.h
@@ -136,11 +136,11 @@ class OctTree : public Tree<ndim,ParticleType,TreeCell>
   void AllocateTreeMemory(int,int,bool);
   void ReallocateMemory(int,int);
   void DeallocateTreeMemory(void);
-  void StockTree(Particle<ndim> *part_gen) {
+  void StockTree(Particle<ndim> *part_gen, bool stock_leaf) {
     ParticleType<ndim>* partdata = reinterpret_cast<ParticleType<ndim>*>(part_gen) ;
-    StockTree(celldata[0], partdata) ;
+    StockTree(celldata[0], partdata, stock_leaf) ;
   }
-  void StockTree(TreeCell<ndim>&, ParticleType<ndim> *);
+  void StockTree(TreeCell<ndim>&, ParticleType<ndim> *, bool);
   void UpdateAllHmaxValues(Particle<ndim> *part_gen) {
       ParticleType<ndim>* partdata = reinterpret_cast<ParticleType<ndim>*>(part_gen) ;
       UpdateHmaxValues(celldata[0], partdata) ;

--- a/src/Hydrodynamics/SphIntegration.cpp
+++ b/src/Hydrodynamics/SphIntegration.cpp
@@ -153,6 +153,11 @@ void SphIntegration<ndim>::CheckBoundaries
 {
   debug2("[SphIntegration::CheckBoundaries]");
 
+  // If all boundaries are open, immediately return to main loop
+  if (simbox.boundary_lhs[0] == openBoundary && simbox.boundary_rhs[0] == openBoundary &&
+      simbox.boundary_lhs[1] == openBoundary && simbox.boundary_rhs[1] == openBoundary &&
+      simbox.boundary_lhs[2] == openBoundary && simbox.boundary_rhs[2] == openBoundary) return;
+
   // Loop over all particles and check if any lie outside the periodic box.
   // If so, then re-position with periodic wrapping.
   //===============================================================================================

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -107,19 +107,19 @@ void SphSimulation<ndim>::ProcessParameters(void)
   simbox.min[0] = floatparams["boxmin[0]"]/simunits.r.outscale;
   simbox.max[0] = floatparams["boxmax[0]"]/simunits.r.outscale;
 
-  if (ndim > 1) {
+  //if (ndim > 1) {
     simbox.boundary_lhs[1] = setBoundaryType(stringparams["boundary_lhs[1]"]);
     simbox.boundary_rhs[1] = setBoundaryType(stringparams["boundary_rhs[1]"]);
     simbox.min[1] = floatparams["boxmin[1]"]/simunits.r.outscale;
     simbox.max[1] = floatparams["boxmax[1]"]/simunits.r.outscale;
-  }
+  //}
 
-  if (ndim == 3) {
+  //if (ndim == 3) {
     simbox.boundary_lhs[2] = setBoundaryType(stringparams["boundary_lhs[2]"]);
     simbox.boundary_rhs[2] = setBoundaryType(stringparams["boundary_rhs[2]"]);
     simbox.min[2] = floatparams["boxmin[2]"]/simunits.r.outscale;
     simbox.max[2] = floatparams["boxmax[2]"]/simunits.r.outscale;
-  }
+  //}
 
   for (int k=0; k<ndim; k++) {
     simbox.size[k] = simbox.max[k] - simbox.min[k];
@@ -698,6 +698,7 @@ void SphSimulation<ndim>::MainLoop(void)
     LocalGhosts->CopyHydroDataToGhosts(simbox, sph);
     sphneib->BuildGhostTree(rebuild_tree, Nsteps, ntreebuildstep, ntreestockstep, timestep, sph);
 #ifdef MPI_PARALLEL
+    mpicontrol->UpdateAllBoundingBoxes(sph->Nhydro, sph, sph->kernp);
     MpiGhosts->CopyHydroDataToGhosts(simbox, sph);
     sphneib->BuildMpiGhostTree(rebuild_tree, Nsteps, ntreebuildstep, ntreestockstep, timestep, sph);
 #endif

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -731,9 +731,6 @@ void SphSimulation<ndim>::MainLoop(void)
         }
       }
 
-      // Copy properties from original particles to ghost particles
-      LocalGhosts->CopyHydroDataToGhosts(simbox, sph);
-
       // Calculate gravitational forces from other distant MPI nodes.
       // Also determines particles that must be exported to other nodes
       // if too close to the domain boundaries

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -702,7 +702,6 @@ void SphSimulation<ndim>::MainLoop(void)
     MpiGhosts->CopyHydroDataToGhosts(simbox, sph);
     sphneib->BuildMpiGhostTree(rebuild_tree, Nsteps, ntreebuildstep, ntreestockstep, timestep, sph);
 #endif
-    sphneib->BuildGhostTree(rebuild_tree, Nsteps, ntreebuildstep, ntreestockstep, timestep, sph);
   }
 
 

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -662,7 +662,7 @@ void SphSimulation<ndim>::MainLoop(void)
   //-----------------------------------------------------------------------------------------------
 #ifdef MPI_PARALLEL
   if (Nsteps%ntreebuildstep == 0 || rebuild_tree) {
-    sphneib->BuildPrunedTree(rank, simbox, mpicontrol->mpinode, sph);
+    sphneib->StockPrunedTree(rank, sph);
     mpicontrol->UpdateAllBoundingBoxes(sph->Nhydro, sph, sph->kernp);
     mpicontrol->LoadBalancing(sph, nbody);
   }
@@ -746,6 +746,10 @@ void SphSimulation<ndim>::MainLoop(void)
       // Also determines particles that must be exported to other nodes
       // if too close to the domain boundaries
 #ifdef MPI_PARALLEL
+      // Pruned trees are used only to compute which particles to export
+      // Therefore we don't need to update them at the start of the loop, and we can do it soon before we need them
+      sphneib->StockPrunedTree(rank, sph);
+
       if (sph->self_gravity == 1) {
         sphneib->UpdateGravityExportList(rank, sph, nbody, simbox);
       }

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -651,9 +651,8 @@ void SphSimulation<ndim>::MainLoop(void)
   nbody->AdvanceParticles(n, nbody->Nnbody, t, timestep, nbody->nbodydata);
 
   // Check all boundary conditions
-  // (DAVID : Move this function to sphint and create an analagous one
-  //  for N-body.  Also, only check this on tree-build steps)
-  if (Nsteps%ntreebuildstep == 0 || rebuild_tree) sphint->CheckBoundaries(simbox,sph);
+  // (DAVID : create an analagous of this function for N-body)
+  sphint->CheckBoundaries(simbox,sph);
 
 
   // Perform the load-balancing step for MPI simulations.  First update the pruned trees on all

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -344,8 +344,6 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGradientMatrices
   }
 
   // Update ghost tree smoothing length values here
-  tree->UpdateAllHmaxValues(mfvdata);
-  if (ghosttree->Ntot > 0) ghosttree->UpdateAllHmaxValues(mfvdata);
 #ifdef MPI_PARALLEL
   if (mfv->Nmpighost > 0) mpighosttree->UpdateAllHmaxValues(mfvdata);
 #endif
@@ -578,10 +576,6 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
   if (cactive == 0) {
     return;
   }
-
-  // Update ghost tree smoothing length values here
-  tree->UpdateAllHmaxValues(mfvdata);
-  //if (ghosttree->Ntot > 0) ghosttree->UpdateAllHmaxValues(ghosttree->celldata[0], mfvdata);
 
 
   // Set-up all OMP threads
@@ -835,9 +829,6 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllGravForces
 #endif
 
   MeshlessFVParticle<ndim> *partdata = mfv->GetMeshlessFVParticleArray();
-
-  // Update ghost tree smoothing length values here
-  tree->UpdateAllHmaxValues(partdata);
 
   // Find list of all cells that contain active particles
   cactive = tree->ComputeActiveCellList(celllist);

--- a/src/MeshlessFV/MfvMusclSimulation.cpp
+++ b/src/MeshlessFV/MfvMusclSimulation.cpp
@@ -74,6 +74,15 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
 
 #ifdef MPI_PARALLEL
 
+  // Pruned trees are used only to compute which particles to export
+  // Therefore we don't need to update them at the start of the loop, and we can do it soon before we need them
+  if (Nsteps%ntreebuildstep == 0 || rebuild_tree) {
+	  mfvneib->BuildPrunedTree(rank, simbox, mpicontrol->mpinode, mfv);
+  }
+  else {
+	  mfvneib->StockPrunedTree(rank, mfv);
+  }
+
   if (mfv->hydro_forces) {
     mfvneib->UpdateHydroExportList(rank, mfv, nbody, simbox);
 
@@ -104,8 +113,15 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
 
 #ifdef MPI_PARALLEL
   if (Nsteps%ntreebuildstep == 0 || rebuild_tree) {
-    mfvneib->BuildPrunedTree(rank, simbox, mpicontrol->mpinode, mfv);
-    mpicontrol->UpdateAllBoundingBoxes(mfv->Nhydro, mfv, mfv->kernp);
+	// Horrible hack in order NOT to trigger a full tree rebuild
+	mfvneib->BuildTree(rebuild_tree,Nsteps+1,2, ntreestockstep,timestep,mfv);
+	if (rebuild_tree) {
+		  mfvneib->BuildPrunedTree(rank, simbox, mpicontrol->mpinode, mfv);
+	}
+	else {
+		mfvneib->StockPrunedTree(rank, mfv);
+	}
+	mpicontrol->UpdateAllBoundingBoxes(mfv->Nhydro, mfv, mfv->kernp);
     mpicontrol->LoadBalancing(mfv, nbody);
   }
 #endif
@@ -116,28 +132,15 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
   mfvneib->InitialiseCellWorkCounters();
 #endif
 
-  if (Nsteps%ntreebuildstep == 0 || rebuild_tree) {
-    tghost = timestep*(FLOAT) (ntreebuildstep - 1);
-    mfvneib->SearchBoundaryGhostParticles(tghost, simbox, mfv);
-    mfvneib->BuildGhostTree(rebuild_tree, Nsteps, ntreebuildstep, ntreestockstep,timestep, mfv);
-    // Re-build and communicate the new pruned trees (since the trees will necessarily change
-    // once there has been communication of particles to new domains)
-#ifdef MPI_PARALLEL
-    mfvneib->BuildPrunedTree(rank, simbox, mpicontrol->mpinode, mfv);
-    mpicontrol->UpdateAllBoundingBoxes(mfv->Nhydro + mfv->NPeriodicGhost, mfv, mfv->kernp);
-    MpiGhosts->SearchGhostParticles(tghost, simbox, mfv);
-      mfvneib->BuildMpiGhostTree(rebuild_tree, Nsteps, ntreebuildstep, ntreestockstep,  timestep, mfv);
-#endif
-  }
-  else {
-    mfv->CopyDataToGhosts(simbox);
-    mfvneib->BuildGhostTree(rebuild_tree, Nsteps, ntreebuildstep, ntreestockstep, timestep, mfv);
-#ifdef MPI_PARALLEL
-    MpiGhosts->CopyHydroDataToGhosts(simbox,mfv);
-    mfvneib->BuildMpiGhostTree(rebuild_tree, Nsteps, ntreebuildstep, ntreestockstep, timestep, mfv);
-#endif
-    mfv->CopyDataToGhosts(simbox);
-  }
+	//tghost = timestep*(FLOAT) (ntreebuildstep - 1);
+	tghost = 0;
+	mfvneib->SearchBoundaryGhostParticles(tghost, simbox, mfv);
+	mfvneib->BuildGhostTree(true, Nsteps, ntreebuildstep, ntreestockstep,timestep, mfv);
+	#ifdef MPI_PARALLEL
+	mpicontrol->UpdateAllBoundingBoxes(mfv->Nhydro + mfv->NPeriodicGhost, mfv, mfv->kernp);
+	MpiGhosts->SearchGhostParticles(tghost, simbox, mfv);
+	  mfvneib->BuildMpiGhostTree(true, Nsteps, ntreebuildstep, ntreestockstep,  timestep, mfv);
+	#endif
 
 
   // Search for new sink particles (if activated) and accrete to existing sinks
@@ -184,6 +187,12 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
     mfv->CopyDataToGhosts(simbox);
 #ifdef MPI_PARALLEL
     if (mfv->self_gravity ==1 ) {
+      if (Nsteps%ntreebuildstep == 0 || rebuild_tree) {
+    	     mfvneib->BuildPrunedTree(rank, simbox, mpicontrol->mpinode, mfv);
+    	}
+      else {
+    		 mfvneib->StockPrunedTree(rank, mfv);
+      }
       mfvneib->UpdateGravityExportList(rank, mfv, nbody, simbox);
       mpicontrol->ExportParticlesBeforeForceLoop(mfv);
     }

--- a/src/Mpi/MpiControl.cpp
+++ b/src/Mpi/MpiControl.cpp
@@ -777,6 +777,7 @@ void MpiControlType<ndim,ParticleType>::ExportParticlesBeforeForceLoop
   }
 
   // Sends are probably finished by now, but we do need to wait so that they can be deallocated
+  MPI_Waitall(Nmpi-1,sendreq_header,MPI_STATUSES_IGNORE);
   MPI_Waitall(Nmpi-1,send_req,MPI_STATUSES_IGNORE);
 
   return;

--- a/src/Tree/BruteForceTree.cpp
+++ b/src/Tree/BruteForceTree.cpp
@@ -290,7 +290,7 @@ void BruteForceTree<ndim,ParticleType,TreeCell>::BuildTree
 
   ltot = 1 ;
   if (Ntot > 0)
-	StockTree(celldata[0], partdata) ;
+	StockTree(celldata[0], partdata, true) ;
   else
 	ltot = 0 ;
 
@@ -305,14 +305,16 @@ void BruteForceTree<ndim,ParticleType,TreeCell>::BuildTree
 template <int ndim, template<int> class ParticleType, template<int> class TreeCell>
 void BruteForceTree<ndim,ParticleType,TreeCell>::StockTree
  (TreeCell<ndim> &cell,                ///< Reference to current tree cell
-  ParticleType<ndim> *partdata) {
+  ParticleType<ndim> *partdata,		   ///< Pointer to particle array
+  bool stock_leaf)					   ///< Wheter to stock also leaf cells
+  {
 
-  StockTreeProperties(cell, partdata) ;
+  if (stock_leaf) StockTreeProperties(cell, partdata) ;
 
   int c = cell.copen ;
   if (c == -1) c = cell.cnext ;
   for (; c < Ncell; c++)
-    StockTreeProperties(celldata[c], partdata) ;
+    if (stock_leaf) StockTreeProperties(celldata[c], partdata) ;
 }
 
 //=================================================================================================
@@ -322,7 +324,7 @@ void BruteForceTree<ndim,ParticleType,TreeCell>::StockTree
 template <int ndim, template<int> class ParticleType, template<int> class TreeCell>
 void BruteForceTree<ndim,ParticleType,TreeCell>::StockTreeProperties
  (TreeCell<ndim> &cell,                ///< Reference to current tree cell
-  ParticleType<ndim> *partdata)        ///< Particle data array
+  ParticleType<ndim> *partdata)		   ///< Particle data array
 {
   int i;                               // Particle counter
   int iaux;                            // Aux. particle i.d. variable

--- a/src/Tree/HydroTree.cpp
+++ b/src/Tree/HydroTree.cpp
@@ -1207,7 +1207,7 @@ void HydroTree<ndim,ParticleType>::StockPrunedTree
 		  int completed_now;
 		  MPI_Waitsome(Nmpi-1,req,&completed_now,which_completed,status);
 
-		  // Unpack the infomration
+		  // Unpack the information
 		  for (int i=0; i<completed_now; i++) {
 			  const int j=which_completed[i];
 			  int iproc=j;
@@ -1216,7 +1216,7 @@ void HydroTree<ndim,ParticleType>::StockPrunedTree
 			  TreeBase<ndim>* treeptr = prunedtree[iproc];
 			  // See how much information we have actually received
 			  int count;
-			  MPI_Get_count(&status[j], MPI_CHAR, &count);
+			  MPI_Get_count(&status[i], MPI_CHAR, &count);
 			  receive_buffer[iproc].resize(count);
 			  // Copy the information into the leaf cells
 			  treeptr->CopyLeafCells(receive_buffer[iproc],TreeBase<ndim>::from_buffer);

--- a/src/Tree/HydroTree.cpp
+++ b/src/Tree/HydroTree.cpp
@@ -1127,8 +1127,6 @@ void HydroTree<ndim,ParticleType>::StockPrunedTree
 	  CodeTiming::BlockTimer timer = timing->StartNewTimer("STOCK_PRUNED_TREE");
 
 	  Particle<ndim> *partdata = hydro->GetParticleArray();
-      tree->UpdateAllHmaxValues(partdata);
-
 	  // Update all work counters in the tree for load-balancing purposes
 	  tree->UpdateWorkCounters();
 

--- a/src/Tree/HydroTree.cpp
+++ b/src/Tree/HydroTree.cpp
@@ -1192,7 +1192,7 @@ void HydroTree<ndim,ParticleType>::StockPrunedTree
 
 			  assert(send_buffer[i].size() == size_send);
 
-			  MPI_Isend(&send_buffer[i][0],size_send,MPI_CHAR,i,4,MPI_COMM_WORLD,&send_req[i]);
+			  MPI_Isend(&send_buffer[i][0],size_send,MPI_CHAR,i,4,MPI_COMM_WORLD,&send_req[j]);
 			  j++;
 
 		  }

--- a/src/Tree/HydroTree.cpp
+++ b/src/Tree/HydroTree.cpp
@@ -1127,6 +1127,7 @@ void HydroTree<ndim,ParticleType>::StockPrunedTree
 	  CodeTiming::BlockTimer timer = timing->StartNewTimer("STOCK_PRUNED_TREE");
 
 	  Particle<ndim> *partdata = hydro->GetParticleArray();
+      tree->UpdateAllHmaxValues(partdata);
 
 	  // Update all work counters in the tree for load-balancing purposes
 	  tree->UpdateWorkCounters();

--- a/src/Tree/KDTree.cpp
+++ b/src/Tree/KDTree.cpp
@@ -818,9 +818,6 @@ void KDTree<ndim,ParticleType,TreeCell>::StockCellProperties
   FLOAT mi;                            // Mass of particle i
   FLOAT p = (FLOAT) 0.0;               // ..
   FLOAT lambda = (FLOAT) 0.0;          // ..
-  TreeCell<ndim> &child1 = celldata[cell.copen];
-  TreeCell<ndim> &child2 = celldata[child1.cnext];
-
 
   // Zero all summation variables for all cells
   if (stock_leaf) {
@@ -935,6 +932,9 @@ void KDTree<ndim,ParticleType,TreeCell>::StockCellProperties
   // For non-leaf cells, sum together two children cells
   //-----------------------------------------------------------------------------------------------
   else if (cell.copen != -1) {
+
+	TreeCell<ndim> &child1 = celldata[cell.copen];
+	TreeCell<ndim> &child2 = celldata[child1.cnext];
 
     if (child1.N > 0) {
       for (k=0; k<ndim; k++) cell.bb.min[k] = min(child1.bb.min[k],cell.bb.min[k]);

--- a/src/Tree/KDTree.cpp
+++ b/src/Tree/KDTree.cpp
@@ -765,7 +765,7 @@ void KDTree<ndim,ParticleType,TreeCell>::StockTree
   int i;                               // Aux. child cell counter
 
   // If cell is not leaf, stock child cells
-  if (cell.level != ltot && cell.copen != -1) {
+  if (cell.copen != -1) {
 	  TreeCell<ndim>& child1 = celldata[cell.copen];
 	  TreeCell<ndim>& child2 = celldata[child1.cnext];
 #if defined _OPENMP
@@ -820,7 +820,7 @@ void KDTree<ndim,ParticleType,TreeCell>::StockCellProperties
   FLOAT lambda = (FLOAT) 0.0;          // ..
 
   // Zero all summation variables for all cells
-  if (stock_leaf) {
+  if ((cell.level==ltot&&stock_leaf) || cell.copen != -1 ) {
 	  cell.Nactive  = 0;
 	  cell.N        = 0;
 	  cell.m        = (FLOAT) 0.0;

--- a/src/Tree/KDTree.cpp
+++ b/src/Tree/KDTree.cpp
@@ -468,7 +468,7 @@ void KDTree<ndim,ParticleType,TreeCell>::DivideTreeCell
       cell.ifirst = -1;
       cell.ilast = -1;
     }
-    StockCellProperties(cell,partdata);
+    StockCellProperties(cell,partdata,true);
     return;
   }
 
@@ -589,7 +589,7 @@ void KDTree<ndim,ParticleType,TreeCell>::DivideTreeCell
   assert(!(cell.ifirst == -1 && cell.ilast == -1));
 
   // Stock all cell properties once constructed
-  StockCellProperties(cell,partdata);
+  StockCellProperties(cell,partdata,true);
 
   return;
 }
@@ -759,7 +759,8 @@ FLOAT KDTree<ndim,ParticleType,TreeCell>::QuickSelect
 template <int ndim, template<int> class ParticleType, template<int> class TreeCell>
 void KDTree<ndim,ParticleType,TreeCell>::StockTree
 (TreeCell<ndim> &cell,                ///< Reference to cell to be stocked
- ParticleType<ndim> *partdata)        ///< SPH particle data array
+ ParticleType<ndim> *partdata,        ///< SPH particle data array
+ bool stock_leaf)					  ///< Whether to stock leaf cells
 {
   int i;                               // Aux. child cell counter
 
@@ -767,29 +768,29 @@ void KDTree<ndim,ParticleType,TreeCell>::StockTree
   if (cell.level != ltot) {
 #if defined _OPENMP
     if (pow(2,cell.level) < Nthreads) {
-#pragma omp parallel for default(none) private(i) shared(cell,partdata) num_threads(2)
+#pragma omp parallel for default(none) private(i) shared(cell,partdata, stock_leaf) num_threads(2)
       for (i=0; i<2; i++) {
-        if (i == 0) StockTree(celldata[cell.c1],partdata);
-        else if (i == 1) StockTree(celldata[cell.c2],partdata);
+        if (i == 0) StockTree(celldata[cell.c1],partdata, stock_leaf);
+        else if (i == 1) StockTree(celldata[cell.c2],partdata, stock_leaf);
       }
 #pragma omp barrier
     }
     else {
       for (i=0; i<2; i++) {
-        if (i == 0) StockTree(celldata[cell.c1],partdata);
-        else if (i == 1) StockTree(celldata[cell.c2],partdata);
+        if (i == 0) StockTree(celldata[cell.c1],partdata, stock_leaf);
+        else if (i == 1) StockTree(celldata[cell.c2],partdata, stock_leaf);
       }
     }
 #else
     for (i=0; i<2; i++) {
-      if (i == 0) StockTree(celldata[cell.c1],partdata);
-      else if (i == 1) StockTree(celldata[cell.c2],partdata);
+      if (i == 0) StockTree(celldata[cell.c1],partdata, stock_leaf);
+      else if (i == 1) StockTree(celldata[cell.c2],partdata, stock_leaf);
     }
 #endif
   }
 
   // Stock node once all children are stocked
-  StockCellProperties(cell,partdata);
+  StockCellProperties(cell,partdata,stock_leaf);
 
   return;
 }
@@ -804,7 +805,8 @@ void KDTree<ndim,ParticleType,TreeCell>::StockTree
 template <int ndim, template<int> class ParticleType, template<int> class TreeCell>
 void KDTree<ndim,ParticleType,TreeCell>::StockCellProperties
  (TreeCell<ndim> &cell,                ///< Reference to current tree cell
-  ParticleType<ndim> *partdata)        ///< Particle data array
+  ParticleType<ndim> *partdata,        ///< Particle data array
+  bool stock_leaf)					   ///< Whether to stock leaf cells
 {
   int i;                               // Particle counter
   int iaux;                            // Aux. particle i.d. variable
@@ -842,7 +844,7 @@ void KDTree<ndim,ParticleType,TreeCell>::StockCellProperties
 
   // If this is a leaf cell, sum over all particles
   //-----------------------------------------------------------------------------------------------
-  if (cell.level == ltot) {
+  if (cell.level == ltot && stock_leaf) {
 
     // First, check if any particles have been accreted and remove them
     // from the linked list.  If cell no longer contains any live particles,
@@ -929,7 +931,7 @@ void KDTree<ndim,ParticleType,TreeCell>::StockCellProperties
   }
   // For non-leaf cells, sum together two children cells
   //-----------------------------------------------------------------------------------------------
-  else {
+  else if (cell.copen != -1) {
 
     if (child1.N > 0) {
       for (k=0; k<ndim; k++) cell.bb.min[k] = min(child1.bb.min[k],cell.bb.min[k]);

--- a/src/Tree/OctTree.cpp
+++ b/src/Tree/OctTree.cpp
@@ -429,7 +429,7 @@ void OctTree<ndim,ParticleType,TreeCell>::BuildTree
   //-----------------------------------------------------------------------------------------------
 
 
-  StockTree(celldata[0],partdata);
+  StockTree(celldata[0],partdata,true);
 #if defined(VERIFY_ALL)
   ValidateTree(partdata);
 #endif
@@ -447,7 +447,8 @@ void OctTree<ndim,ParticleType,TreeCell>::BuildTree
 template <int ndim, template<int> class ParticleType, template<int> class TreeCell>
 void OctTree<ndim,ParticleType,TreeCell>::StockTree
  (TreeCell<ndim> &rootcell,            ///< Reference to cell to be stocked
-  ParticleType<ndim> *partdata)        ///< SPH particle data array
+  ParticleType<ndim> *partdata,        ///< SPH particle data array
+  bool stock_leaf)					   ///< Whether or not to stock leaf cells
 {
   int c,cc;                            // Cell counters
   int cend;                            // Last particle in cell
@@ -496,7 +497,7 @@ void OctTree<ndim,ParticleType,TreeCell>::StockTree
 
       // If this is a leaf cell, sum over all particles
       //-------------------------------------------------------------------------------------------
-      if (cell.copen == -1) {
+      if (cell.copen == -1 && stock_leaf) {
 
         // First, check if any particles have been accreted and remove them
         // from the linked list.  If cell no longer contains any live particles,
@@ -585,7 +586,7 @@ void OctTree<ndim,ParticleType,TreeCell>::StockTree
       }
       // For non-leaf cells, sum over all child cells
       //-------------------------------------------------------------------------------------------
-      else {
+      else if (cell.copen != -1) {
 
         // Set limits for children (maximum of 8 but may be less)
         cc   = cell.copen;

--- a/src/Tree/Tree.cpp
+++ b/src/Tree/Tree.cpp
@@ -1294,12 +1294,21 @@ void Tree<ndim,ParticleType,TreeCell>::CopyLeafCells
 	vector<char>::const_iterator iter = buffer.begin();
 	for (int i=0; i< Nleaf_indices.size(); i++) {
 		const int j=Nleaf_indices[i];
-		if (dir == TreeBase<ndim>::to_buffer)
+		if (dir == TreeBase<ndim>::to_buffer) {
+			assert(celldata[j].copen==-1);
 			append_bytes<TreeCell<ndim> >(buffer, &(celldata[j])) ;
-		else if (dir == TreeBase<ndim>::from_buffer)
+		}
+		else if (dir == TreeBase<ndim>::from_buffer) {
+			assert(celldata[j].copen==-1);
 			unpack_bytes<TreeCell<ndim> >(&(celldata[j]), iter);
+		}
 	}
-	if (dir== TreeBase<ndim>::from_buffer) assert(iter == buffer.end());
+	if (dir== TreeBase<ndim>::from_buffer) {
+		assert(iter == buffer.end());
+	}
+	else {
+		assert(buffer.size()/sizeof(TreeCell<ndim>)==Nleaf_indices.size());
+	}
  }
 
 

--- a/src/Tree/Tree.cpp
+++ b/src/Tree/Tree.cpp
@@ -1100,7 +1100,6 @@ int Tree<ndim,ParticleType,TreeCell>::CreatePrunedTreeForMpiNode
   TreeBase<ndim> *prunedtree)         ///< [out] List of cell pointers in pruned tree
 {
   int c;                               // Cell counter
-  int cnext;                           // id of next cell in tree
   int k;                               // Neighbour counter
   int Nprunedcell = 0;                 // No. of cells in newly created pruned tree
   int *newCellIds;                     // New cell ids in pruned tree
@@ -1225,8 +1224,10 @@ int Tree<ndim,ParticleType,TreeCell>::CreatePrunedTreeForMpiNode
     assert(prunedcells[c].copen < prunedcells[c].cnext);
   }
 
+#ifndef NDEBUG
   // If selected, verify that pruned tree pointers are correctly set-up
   assert(Nprunedcell <= Nprunedcellmax);
+  int cnext;                           // id of next cell in tree
   for (c=0; c<Nprunedcell; c++) {
     if (prunedcells[c].copen != -1) cnext = prunedcells[c].copen;
     else cnext = prunedcells[c].cnext;
@@ -1235,6 +1236,7 @@ int Tree<ndim,ParticleType,TreeCell>::CreatePrunedTreeForMpiNode
     assert(prunedcells[c].cnext > 0);
     assert(prunedcells[c].copen < prunedcells[c].cnext);
   }
+#endif
 
 
   delete[] newCellIds;

--- a/src/Tree/Tree.cpp
+++ b/src/Tree/Tree.cpp
@@ -1298,9 +1298,8 @@ void Tree<ndim,ParticleType,TreeCell>::CopyLeafCells
 			append_bytes<TreeCell<ndim> >(buffer, &(celldata[j])) ;
 		else if (dir == TreeBase<ndim>::from_buffer)
 			unpack_bytes<TreeCell<ndim> >(&(celldata[j]), iter);
-		iter += sizeof(TreeCell<ndim>);
 	}
-	assert(iter == buffer.end());
+	if (dir== TreeBase<ndim>::from_buffer) assert(iter == buffer.end());
  }
 
 


### PR DESCRIPTION
This is not finished so it is too early to merge; it seems to work but I haven't tested it extensively. And it's implemented only for SPH at the moment. But I need to discuss a few things, see below.

In the SPH loop, I've put the stocking of the pruned trees just before we look for which particles to export. We don't use the pruned trees before this, so there is no need to stock the tree before the h calculation I believe. But we do need to update hmax in the main tree before we stock the pruned tree, or the pruned trees will have the wrong ones. Am I right? This means that I should remove the update h max from the compute force routines if using MPI. If we are on a tree rebuild step, all of this is a bit overkill because there is no need to fully restock the pruned tree. We could actually build the pruned trees after the h calculation, in the same way as we stock them there, because they are not needed before!

I also restock the pruned tree before the load balancing - currently we were rebuilding it which is unnecessary. But there's a problem: we are not restocking the local tree between moving the particles and doing the load balancing. So what is the point in rebuilding/restocking the pruned trees?  It's just going to be the same because it's a copy of the local tree. I think we either need to stock both of them, or none; but only one does not make sense. I can't decide if it's worth to do the stocking - not doing it just means that the load balancing is suboptimal, but it's not terribly wrong.

Another thing was the UpdateBoundingBoxes call - I was not sure wheter it's needed in a non-rebuild step - for now I've added it. I'm not sure where we actually use bounding boxes, which would be good to know...