### PR TITLE
Newparticles2

### DIFF
--- a/src/Common/IC.cpp
+++ b/src/Common/IC.cpp
@@ -221,7 +221,7 @@ void Ic<ndim>::BinaryAccretion(void)
     if (Nbox1 > 0) {
       r1 = new FLOAT[ndim*Nbox1];
       if (part_dist == "random") {
-        AddRandomBox(Nbox1, box1, r1);
+        AddRandomBox(Nbox1, box1, r1, sim->randnumb);
       }
       else if (part_dist == "cubic_lattice") {
         AddCubicLattice(Nbox1, Nlattice1, box1, true, r1);
@@ -255,7 +255,7 @@ void Ic<ndim>::BinaryAccretion(void)
     if (Nbox2 > 0) {
       r2 = new FLOAT[ndim*Nbox2];
       if (part_dist == "random") {
-        AddRandomBox(Nbox2, box2, r2);
+        AddRandomBox(Nbox2, box2, r2, sim->randnumb);
       }
       else if (part_dist == "cubic_lattice") {
         AddCubicLattice(Nbox2, Nlattice2, box2, true, r2);
@@ -617,7 +617,7 @@ void Ic<ndim>::UniformBox(void)
   // depending on the chosen particle distribution
   if (particle_dist == "random") {
     r = new FLOAT[ndim*Npart];
-    AddRandomBox(Npart, simbox, r);
+    AddRandomBox(Npart, simbox, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice") {
     Npart = Nbox;
@@ -701,7 +701,7 @@ void Ic<ndim>::UniformSphere(void)
     AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
-    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
+    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r, sim->randnumb);
     if (Nsphere != Npart) {
       cout << "Warning! Unable to converge to required "
            << "no. of ptcls due to lattice symmetry" << endl;
@@ -1168,7 +1168,7 @@ void Ic<ndim>::NohProblem(void)
     AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
-    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
+    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r, sim->randnumb);
     if (Nsphere != Npart) cout << "Warning! Unable to converge to required "
                                << "no. of ptcls due to lattice symmetry" << endl;
     Npart = Nsphere;
@@ -1411,7 +1411,7 @@ void Ic<ndim>::BossBodenheimer(void)
     AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
-    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
+    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r, sim->randnumb);
     if (Nsphere != Npart) {
       cout << "Warning! Unable to converge to required "
            << "no. of ptcls due to lattice symmetry" << endl;
@@ -1694,7 +1694,7 @@ void Ic<ndim>::TurbulentCore(void)
     AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
-    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
+    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r, sim->randnumb);
     assert(Nsphere <= Npart);
     if (Nsphere != Npart)
       cout << "Warning! Unable to converge to required "
@@ -1849,7 +1849,7 @@ void Ic<ndim>::BondiAccretion(void)
     AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
-    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
+    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r, sim->randnumb);
     if (Nsphere != Npart)
       cout << "Warning! Unable to converge to required "
            << "no. of ptcls due to lattice symmetry" << endl;
@@ -2447,7 +2447,7 @@ void Ic<ndim>::BlastWave(void)
   // Add a cube of random particles defined by the simulation bounding box and
   // depending on the chosen particle distribution
   if (particle_dist == "random") {
-    AddRandomBox(Nbox, simbox, r);
+    AddRandomBox(Nbox, simbox, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice") {
     AddCubicLattice(Nbox, Nlattice, simbox, true, r);
@@ -2580,7 +2580,7 @@ void Ic<ndim>::SedovBlastWave(void)
   // Add a cube of random particles defined by the simulation bounding box and
   // depending on the chosen particle distribution
   if (particle_dist == "random") {
-    AddRandomBox(Nbox, simbox, r);
+    AddRandomBox(Nbox, simbox, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice") {
     AddCubicLattice(Nbox, Nlattice, simbox, true, r);
@@ -2610,24 +2610,8 @@ void Ic<ndim>::SedovBlastWave(void)
   hydro->Ntot = hydro->Nhydro;
   for (i=0; i<hydro->Nhydro; i++) hydro->GetParticlePointer(i).flags.set_flag(active);
 
-  // Search ghost particles
-  //sim->sphneib->SearchBoundaryGhostParticles(0.0,simbox,sph);
-
   sim->initial_h_provided = true;
   sim->rebuild_tree = true;
-  //sphneib->BuildTree(rebuild_tree,n,ntreebuildstep,ntreestockstep,
-                     //hydro->Ntot,hydro->Nhydromax,partdata,sph,timestep);
-
-  //sphneib->UpdateAllSphProperties(hydro->Nhydro,hydro->Ntot,partdata,sph,nbody);
-
-  // Update neighbour tre
-  sim->rebuild_tree = true;
-  //sphneib->BuildTree(rebuild_tree,n,ntreebuildstep,ntreestockstep,
-                     //hydro->Ntot,hydro->Nhydromax,partdata,sph,timestep);
-
-  // Calculate all SPH properties
-  //sphneib->UpdateAllSphProperties(hydro->Nhydro,hydro->Ntot,partdata,sph,nbody);
-
 
 
   // Now calculate which particles are hot
@@ -2637,7 +2621,10 @@ void Ic<ndim>::SedovBlastWave(void)
   for (i=0; i<Nbox; i++) {
     Particle<ndim>& part = hydro->GetParticlePointer(i);
     drsqd = DotProduct(part.r,part.r,ndim);
-    if (drsqd < r_hot*r_hot) {
+    hotlist[i] = 0;
+    Ncold++;
+
+    /*if (drsqd < r_hot*r_hot) {
       hotlist[i] = 1;
       if (smooth_ic == 1) part.u = part.m*hydro->kernp->w0(hydro->kernp->kernrange*sqrt(drsqd)/r_hot);
       else part.u = part.m;
@@ -2648,7 +2635,7 @@ void Ic<ndim>::SedovBlastWave(void)
     else {
       hotlist[i] = 0;
       Ncold++;
-    }
+    }*/
   }
 
   // Normalise the energies
@@ -2918,7 +2905,7 @@ void Ic<ndim>::SpitzerExpansion(void)
     AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
-    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
+    Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r, sim->randnumb);
     if (Nsphere != Npart) {
       cout << "Warning! Unable to converge to required "
            << "no. of ptcls due to lattice symmetry" << endl;
@@ -3624,7 +3611,8 @@ template <int ndim>
 void Ic<ndim>::AddRandomBox
  (const int Npart,                     ///< [in] No. of particles
   const DomainBox<ndim> box,           ///< [in] Bounding box containing particles
-  FLOAT *r)                            ///< [out] Positions of particles
+  FLOAT *r,                            ///< [out] Positions of particles
+  RandomNumber *randnumb)              ///< [inout] Pointer to random number generator
 {
   debug2("[Ic::AddRandomBox]");
   assert(r);
@@ -3689,7 +3677,8 @@ int Ic<ndim>::AddLatticeSphere
   const FLOAT rcentre[ndim],           ///< [in] Position of sphere centre
   const FLOAT radius,                  ///< [in] Radius of sphere
   const string particle_dist,          ///< [in] String of lattice type
-  FLOAT *r)                            ///< [out] Positions of particles in sphere
+  FLOAT *r,                            ///< [out] Positions of particles in sphere
+  RandomNumber *randnumb)              ///< [inout] Pointer to random number generator
 {
   int i,k;                             // Particle and dimension counters
   int Naux;                            // Aux. particle number
@@ -3733,7 +3722,7 @@ int Ic<ndim>::AddLatticeSphere
   // during tree construction)
   if (ndim == 2) {
     FLOAT rtemp[ndim];
-    theta = twopi*sim->randnumb->floatrand();
+    theta = twopi*randnumb->floatrand();
     for (i=0; i<Naux; i++) {
       for (k=0; k<ndim; k++) rtemp[k] = raux[ndim*i + k];
       raux[ndim*i] = rtemp[0]*cos(theta) - rtemp[1]*sin(theta);
@@ -3741,9 +3730,9 @@ int Ic<ndim>::AddLatticeSphere
     }
   }
   else if (ndim == 3) {
-    theta = acos(sqrtf(sim->randnumb->floatrand()));
-    phi   = twopi*sim->randnumb->floatrand();
-    psi   = twopi*sim->randnumb->floatrand();
+    theta = acos(sqrtf(randnumb->floatrand()));
+    phi   = twopi*randnumb->floatrand();
+    psi   = twopi*randnumb->floatrand();
     EulerAngleArrayRotation(Naux, phi, theta, psi, raux);
   }
 
@@ -4728,7 +4717,7 @@ void Ic<ndim>::EvrardCollapse()
 	  AddRandomSphere(Npart, rcentre, radius, pos, sim->randnumb);
     }
 	else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
-	  Npart = AddLatticeSphere(Npart, rcentre, radius, particle_dist, pos) ;
+	  Npart = AddLatticeSphere(Npart, rcentre, radius, particle_dist, pos, sim->randnumb) ;
 	}
 	else {
 	  string message = "Invalid particle distribution option";
@@ -4852,7 +4841,7 @@ void Ic<ndim>::DustyBox(void)
   // Add a cube of random particles defined by the simulation bounding box and
   // depending on the chosen particle distribution
   if (particle_dist == "random") {
-    AddRandomBox(Nbox, simbox, r);
+    AddRandomBox(Nbox, simbox, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice") {
     AddCubicLattice(Nbox, Nlattice, simbox, true, r);

--- a/src/Common/IC.cpp
+++ b/src/Common/IC.cpp
@@ -698,7 +698,7 @@ void Ic<ndim>::UniformSphere(void)
 
   // Create the sphere depending on the choice of initial particle distribution
   if (particle_dist == "random") {
-    AddRandomSphere(Npart, rcentre, radius, r);
+    AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
     Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
@@ -1165,7 +1165,7 @@ void Ic<ndim>::NohProblem(void)
 
   // Create the sphere depending on the choice of initial particle distribution
   if (particle_dist == "random") {
-    AddRandomSphere(Npart, rcentre, radius, r);
+    AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
     Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
@@ -1408,7 +1408,7 @@ void Ic<ndim>::BossBodenheimer(void)
 
   // Create the sphere depending on the choice of initial particle distribution
   if (particle_dist == "random") {
-    AddRandomSphere(Npart, rcentre, radius, r);
+    AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
     Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
@@ -1691,7 +1691,7 @@ void Ic<ndim>::TurbulentCore(void)
 
   // Create the sphere depending on the choice of initial particle distribution
   if (particle_dist == "random") {
-    AddRandomSphere(Npart, rcentre, radius, r);
+    AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
     Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
@@ -1846,7 +1846,7 @@ void Ic<ndim>::BondiAccretion(void)
 
   // Create the sphere depending on the choice of initial particle distribution
   if (particle_dist == "random") {
-    AddRandomSphere(Npart, rcentre, radius, r);
+    AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
     Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
@@ -2915,7 +2915,7 @@ void Ic<ndim>::SpitzerExpansion(void)
 
   // Create the sphere depending on the choice of initial particle distribution
   if (particle_dist == "random") {
-    AddRandomSphere(Npart, rcentre, radius, r);
+    AddRandomSphere(Npart, rcentre, radius, r, sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
     Nsphere = AddLatticeSphere(Npart, rcentre, radius, particle_dist, r);
@@ -3649,7 +3649,8 @@ void Ic<ndim>::AddRandomSphere
  (const int Npart,                     ///< [in] No. of particles in sphere
   const FLOAT rcentre[ndim],           ///< [in] Position of sphere centre
   const FLOAT radius,                  ///< [in] Radius of sphere
-  FLOAT *r)                            ///< [out] Positions of particles in sphere
+  FLOAT *r,                            ///< [out] Positions of particles in sphere
+  RandomNumber *randnumb)              ///< [inout] Pointer to random number generator
 {
   int i,k;                             // Particle and dimension counters
   FLOAT rad;                           // Radius of particle
@@ -3665,7 +3666,7 @@ void Ic<ndim>::AddRandomSphere
     // Continously loop until random particle lies inside sphere
     do {
       for (k=0; k<ndim; k++)
-      rpos[k] = (FLOAT) 1.0 - (FLOAT) 2.0*sim->randnumb->floatrand();
+      rpos[k] = (FLOAT) 1.0 - (FLOAT) 2.0*randnumb->floatrand();
       rad = DotProduct(rpos,rpos,ndim);
     } while (rad > 1.0);
 
@@ -4724,7 +4725,7 @@ void Ic<ndim>::EvrardCollapse()
 	pos = new FLOAT[ndim*Npart];
 
     if (particle_dist == "random") {
-	  AddRandomSphere(Npart, rcentre, radius, pos);
+	  AddRandomSphere(Npart, rcentre, radius, pos, sim->randnumb);
     }
 	else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
 	  Npart = AddLatticeSphere(Npart, rcentre, radius, particle_dist, pos) ;

--- a/src/Common/IC.cpp
+++ b/src/Common/IC.cpp
@@ -1538,7 +1538,7 @@ void Ic<ndim>::BlobTest(void)
   }
   vector<FLOAT> r_background(ndim*Nbox);
   if (particle_dist == "random") {
-    AddRandomBox(Nbox, simbox, &r_background[0]);
+    AddRandomBox(Nbox, simbox, &r_background[0], sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice") {
     AddCubicLattice(Nbox, Nlattice, simbox, true, &r_background[0]);
@@ -1574,10 +1574,10 @@ void Ic<ndim>::BlobTest(void)
   vector<FLOAT> r(ndim*Nsphere);
   // Create the sphere depending on the choice of initial particle distribution
   if (particle_dist == "random") {
-    AddRandomSphere(Nsphere, rcentre, radius, &r[0]);
+    AddRandomSphere(Nsphere, rcentre, radius, &r[0], sim->randnumb);
   }
   else if (particle_dist == "cubic_lattice" || particle_dist == "hexagonal_lattice") {
-    Nsphere = AddLatticeSphere(Nsphere, rcentre, radius, particle_dist, &r[0]);
+    Nsphere = AddLatticeSphere(Nsphere, rcentre, radius, particle_dist, &r[0], sim->randnumb);
 //    if (Nsphere != Npart) cout << "Warning! Unable to converge to required "
 //                               << "no. of ptcls due to lattice symmetry" << endl;
   }

--- a/src/Common/IC.cpp
+++ b/src/Common/IC.cpp
@@ -3619,7 +3619,7 @@ void Ic<ndim>::AddRandomBox
 
   for (int i=0; i<Npart; i++) {
     for (int k=0; k<ndim; k++) {
-      r[ndim*i + k] = box.min[k] + (box.max[k] - box.min[k])*sim->randnumb->floatrand();
+      r[ndim*i + k] = box.min[k] + (box.max[k] - box.min[k])*randnumb->floatrand();
     }
   }
 
@@ -3695,7 +3695,7 @@ int Ic<ndim>::AddLatticeSphere
 
   // Set parameters for box and lattice to ensure it contains enough particles
   for (k=0; k<3; k++) Nlattice[k] = 1;
-  for (k=0; k<ndim; k++) Nlattice[k] = (int) (3.0*powf((FLOAT) Npart, invndim));
+  for (k=0; k<ndim; k++) Nlattice[k] = (int) (3.0*powf((FLOAT) Npart, (FLOAT)1/ndim));
   for (k=0; k<ndim; k++) box1.min[k] = -2.0;
   for (k=0; k<ndim; k++) box1.max[k] = 2.0;
   Naux = Nlattice[0]*Nlattice[1]*Nlattice[2];

--- a/src/Common/Parameters.cpp
+++ b/src/Common/Parameters.cpp
@@ -460,13 +460,16 @@ void Parameters::SetDefaultValues(void)
   //-----------------------------------------------------------------------------------------------
   floatparams["dt_python"] = 8.0;
 
-  // Dust Parameters
+  // Dust parameters
   //-----------------------------------------------------------------------------------------------
   stringparams["dust_forces"] = "none" ;
   stringparams["drag_law"] = "none" ;
   floatparams["drag_coeff"] = 0 ;
   floatparams["dust_mass_factor"] = 1 ;
 
+  // Supernova feedback parameters
+  //-----------------------------------------------------------------------------------------------
+  stringparams["supernova_feedback"] = "none";
 
   return;
 }

--- a/src/Common/Render.cpp
+++ b/src/Common/Render.cpp
@@ -145,18 +145,18 @@ int Render<ndim>::CreateColumnRenderingGrid
   cout << "Generating rendered image!" << endl;
 
   // First, verify x, y, m, rho, h and render strings are valid
-  snap.ExtractArray(xstring,typepart,&xvalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray(ystring,typepart,&yvalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray(renderstring,typepart,&rendervalues,&idummy,scaling_factor,renderunit);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray("m",typepart,&mvalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray("rho",typepart,&rhovalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray("h",typepart,&hvalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
+  snap.ExtractArray(xstring, typepart, &xvalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray(ystring, typepart, &yvalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray(renderstring, typepart, &rendervalues, &idummy, scaling_factor, renderunit);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray("m", typepart, &mvalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray("rho", typepart, &rhovalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray("h", typepart, &hvalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
 
   // If any are invalid, exit here with failure code
   if (arraycheck == 0) return -1;
@@ -267,7 +267,7 @@ int Render<ndim>::CreateSliceRenderingGrid
   float* values,                       ///< [out] Rendered values for plotting
   const int Ngrid,                     ///< [in] No. of grid points (ixgrid*iygrid)
   SphSnapshotBase &snap,               ///< [inout] Snapshot object reference,
-  const string typepart,                          ///< [in] Type of particles to render
+  const string typepart,               ///< [in] Type of particles to render
   float &scaling_factor)               ///< [in] Rendered quantity scaling factor
 {
   int arraycheck = 1;                  // Verification flag
@@ -303,20 +303,20 @@ int Render<ndim>::CreateSliceRenderingGrid
       (ystring != "x" && ystring != "y" && ystring != "z")) return -1;
 
   // First, verify x, y, z, m, rho, h and render strings are valid
-  snap.ExtractArray(xstring,typepart,&xvalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray(ystring,typepart,&yvalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray(zstring,typepart,&zvalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray(renderstring,typepart,&rendervalues,&idummy,scaling_factor,renderunit);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray("m",typepart,&mvalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray("rho",typepart,&rhovalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
-  snap.ExtractArray("h",typepart,&hvalues,&idummy,dummyfloat,dummystring);
-  arraycheck = min(idummy,arraycheck);
+  snap.ExtractArray(xstring, typepart, &xvalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray(ystring, typepart, &yvalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray(zstring, typepart, &zvalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray(renderstring, typepart, &rendervalues, &idummy, scaling_factor, renderunit);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray("m", typepart, &mvalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray("rho", typepart, &rhovalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
+  snap.ExtractArray("h", typepart, &hvalues, &idummy, dummyfloat, dummystring);
+  arraycheck = min(idummy, arraycheck);
 
   // If any are invalid, exit here with failure code
   if (arraycheck == 0) return -1;

--- a/src/Feedback/Supernova.cpp
+++ b/src/Feedback/Supernova.cpp
@@ -72,18 +72,18 @@ Supernova<ndim>::~Supernova()
 //=================================================================================================
 template <int ndim>
 void Supernova<ndim>::SupernovaInjection
- (int n,                                     ///< ..
-  int level_max,                             ///< ..
-  int SNid,                                  ///< ..
-  FLOAT t,                                   ///< ..
-  FLOAT SNpos[ndim],                         ///< ..
-  FLOAT Einj,                                ///< ..
+ (int n,                                     ///< Current integer time
+  int level_max,                             ///< Max. block timestep level
+  int SNid,                                  ///< i.d. of supernova
+  FLOAT t,                                   ///< Physical simulation time
+  FLOAT SNpos[ndim],                         ///< Position of supernova
+  FLOAT Einj,                                ///< Total energy injection of supernova
   FLOAT R_therm_kin,                         ///< ..
-  FLOAT Minj,                                ///< ..
+  FLOAT Minj,                                ///< Total injected mass
   FLOAT Rinj,                                ///< ..
-  Hydrodynamics<ndim> *hydro,                ///< ..
-  NeighbourSearch<ndim> *neibsearch,         ///< ..
-  RandomNumber *randnumb)                    ///< ..
+  Hydrodynamics<ndim> *hydro,                ///< Pointer to hydrodynamics object
+  NeighbourSearch<ndim> *neibsearch,         ///< Pointer to neighbour search object
+  RandomNumber *randnumb)                    ///< Pointer to random number generator
 {
   // LOCAL VARIABLES
   int i;                                     // ..

--- a/src/Feedback/Supernova.cpp
+++ b/src/Feedback/Supernova.cpp
@@ -1,0 +1,178 @@
+//=================================================================================================
+//  Supernova.cpp
+//  All routines for creating Supernova events via adding new particles to simulation
+//
+//  This file is part of GANDALF :
+//  Graphical Astrophysics code for N-body Dynamics And Lagrangian Fluids
+//  https://github.com/gandalfcode/gandalf
+//  Contact : gandalfcode@gmail.com
+//
+//  Copyright (C) 2013  D. A. Hubber, G. Rosotti
+//
+//  GANDALF is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  GANDALF is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License (http://www.gnu.org/licenses) for more details.
+//=================================================================================================
+
+
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <iostream>
+#include <math.h>
+#include "Debug.h"
+#include "Exception.h"
+#include "Hydrodynamics.h"
+#include "IC.h"
+#include "InlineFuncs.h"
+#include "Nbody.h"
+#include "NbodyParticle.h"
+#include "Parameters.h"
+#include "Precision.h"
+#include "Sinks.h"
+#include "StarParticle.h"
+#include "Supernova.h"
+using namespace std;
+
+
+
+//=================================================================================================
+//  Supernova::Supernova
+/// Supernova class constructor
+/// This class contains the code to do a single supernova explosion
+//=================================================================================================
+template <int ndim>
+Supernova<ndim>::Supernova()
+{
+}
+
+
+
+//=================================================================================================
+//  Supernova::~Supernova
+/// Supernova class destructor
+//=================================================================================================
+template <int ndim>
+Supernova<ndim>::~Supernova()
+{
+}
+
+
+
+//=================================================================================================
+//  Supernova::SupernovaInjection
+/// Supernova injection
+/// Pass: SNpos, Einj, R_therm_kin, Minj, Rinj, SNid, hydro
+//=================================================================================================
+template <int ndim>
+void Supernova<ndim>::SupernovaInjection
+ (int n,                                     ///< ..
+  int level_max,                             ///< ..
+  int SNid,                                  ///< ..
+  FLOAT t,                                   ///< ..
+  FLOAT SNpos[ndim],                         ///< ..
+  FLOAT Einj,                                ///< ..
+  FLOAT R_therm_kin,                         ///< ..
+  FLOAT Minj,                                ///< ..
+  FLOAT Rinj,                                ///< ..
+  Hydrodynamics<ndim> *hydro,                ///< ..
+  NeighbourSearch<ndim> *neibsearch,         ///< ..
+  RandomNumber *randnumb)                    ///< ..
+{
+  // LOCAL VARIABLES
+  int i;                                     // ..
+  int j;                                     // ..
+  int k;                                     // ..
+  int id;                                    // ..
+  int Ninject = (int) (Minj/hydro->mmean);   // No. of new hydro ptcls to inject as hot SN gas
+  int Nneib;                                 // ..
+  int Nneibmax = 100;                        // ..
+  int nSNinject;                             // No. of ptcls accelerated by the SN (ninject + counter)
+  FLOAT *pos;                                // position array for all injected particles
+  FLOAT vpart[ndim];                         // radial velocities for injected particles
+  FLOAT rpart[ndim];                         // ..
+  FLOAT drsqd;                               // distance^2 from SNpos
+  FLOAT drmag;                               // ..
+  FLOAT vrad_mag;                            // radial velocity magnitude [code units velocity]
+  FLOAT etherm_mag;                          // thermal energy to be injected per particle [code units E]
+  FLOAT uinj;                                // internal energy to be added to the particles [code units u = erg/g]
+  int *neiblist = new int[Nneibmax];
+
+  // Randomly draw the new position within Rinj
+  pos = new FLOAT[ndim*Ninject];
+  Ic<ndim>::AddRandomSphere(Ninject, SNpos, Rinj, pos, randnumb);
+
+  // Do a neighbour search to find existing particles inside sphere.  If memory is not large
+  // enough, then increase the size.
+  Nneib = neibsearch->GetGatherNeighbourList(SNpos, Rinj, hydro->GetParticleArray(),
+                                             hydro->Nhydro, Nneibmax, neiblist);
+  while (Nneib == -1) {
+    delete[] neiblist;
+    Nneibmax *= 2;
+    neiblist = new int[Nneibmax];
+    Nneib = neibsearch->GetGatherNeighbourList(SNpos, Rinj, hydro->GetParticleArray(),
+                                               hydro->Nhydro, Nneibmax, neiblist);
+  };
+
+  // Total number of hot SN particles = new particles + existing particles within sphere
+  nSNinject = Ninject + Nneib;
+
+  // Give the particles their radial velocities
+  vrad_mag = sqrt(2./( (FLOAT) nSNinject)/(hydro->mmean)*Einj*1./(R_therm_kin+1.));
+  etherm_mag = (1./(1.+1./R_therm_kin))*Einj/( (FLOAT) nSNinject);
+  uinj = etherm_mag/(hydro->mmean);
+
+  // Loop over existing particles and accelerate them
+  for (j=0; j<Nneib; j++) {
+    i = neiblist[j];
+
+    Particle<ndim>& part = hydro->GetParticlePointer(i);
+    // determine radial velocity vector for this particle
+    drsqd = DotProduct(part.r, SNpos, ndim);
+    drmag = sqrt(drsqd) + small_number;
+    part.u += uinj;
+
+    for (k=0;k<ndim;k++){
+      part.v[k] = (part.r[k] - SNpos[k])/drmag * vrad_mag;
+
+      // reset acceleration to 0??
+      part.a[k]=(FLOAT) 0.0;
+    }
+  }
+
+  // Loop over all new particles, create them one by one and initialize
+  for (j=0; j<Ninject; j++){
+
+    for (k=0; k<ndim; k++) rpart[k] = pos[ndim*i+k];
+    // Not sure what this means??
+    //drsqd = DotProduct(part.r, SNpos, ndim);
+    //drmag = sqrt(drsqd)+small_number;
+
+    for (k=0; k<ndim; k++) vpart[k] = (rpart[k] - SNpos[k])/drmag * vrad_mag;
+
+    // Get new particle i
+    Particle<ndim> &part = hydro->CreateNewParticle(gas, gas_type, n, level_max, t,
+                                                    hydro->mmean, uinj, rpart, vpart);
+
+    // Set SNid?
+    // Set smoothing length?
+  }
+
+
+  delete[] pos;
+  delete[] neiblist;
+
+  return;
+}
+
+
+
+template class Supernova<1>;
+template class Supernova<2>;
+template class Supernova<3>;

--- a/src/Feedback/Supernova.cpp
+++ b/src/Feedback/Supernova.cpp
@@ -109,7 +109,6 @@ void Supernova<ndim>::SupernovaInjection
   pos = new FLOAT[ndim*Ninject];
   Ic<ndim>::AddRandomSphere(Ninject, SNpos, Rinj, pos, randnumb);
   //Ninject = Ic<ndim>::AddLatticeSphere(Ninject, SNpos, Rinj, "hexagonal_lattice", pos, randnumb);
-  //FLOAT mnew = Minj/(FLOAT) Ninject;
 
   // Do a neighbour search to find existing particles inside sphere.  If memory is not large
   // enough, then increase the size.
@@ -135,7 +134,9 @@ void Supernova<ndim>::SupernovaInjection
   cout << "etot : " << (1.0/(1.0 + 1.0/R_therm_kin))*Einj
        << "    etherm_mag : " << etherm_mag << "     uinj : " << uinj << endl;
 
+
   // Loop over existing particles and accelerate them
+  //-----------------------------------------------------------------------------------------------
   for (j=0; j<Nneib; j++) {
     i = neiblist[j];
 
@@ -151,11 +152,12 @@ void Supernova<ndim>::SupernovaInjection
       part.v[k] = (part.r[k] - SNpos[k])/drmag * vrad_mag;
 
       // reset acceleration to 0??
-      part.a[k]=(FLOAT) 0.0;
+      part.a[k] = (FLOAT) 0.0;
     }
   }
 
   // Loop over all new particles, create them one by one and initialize
+  //-----------------------------------------------------------------------------------------------
   for (j=0; j<Ninject; j++){
 
     for (k=0; k<ndim; k++) rpart[k] = pos[ndim*j+k];

--- a/src/Feedback/Supernova.cpp
+++ b/src/Feedback/Supernova.cpp
@@ -42,27 +42,6 @@ using namespace std;
 
 
 
-//=================================================================================================
-//  Supernova::Supernova
-/// Supernova class constructor
-/// This class contains the code to do a single supernova explosion
-//=================================================================================================
-template <int ndim>
-Supernova<ndim>::Supernova()
-{
-}
-
-
-
-//=================================================================================================
-//  Supernova::~Supernova
-/// Supernova class destructor
-//=================================================================================================
-template <int ndim>
-Supernova<ndim>::~Supernova()
-{
-}
-
 
 
 //=================================================================================================
@@ -173,7 +152,7 @@ void Supernova<ndim>::SupernovaInjection
 
     // Get new particle i
     Particle<ndim> &part = hydro->CreateNewParticle(gas, gas_type, n, level_step, level_max,
-                                                    t, hydro->mmean, uinj, rpart, vpart);
+                                                    t, hydro->mmean, uinj, rpart, vpart,sim);
 
     // Set SNid?
     // Set smoothing length?

--- a/src/Feedback/Supernova.cpp
+++ b/src/Feedback/Supernova.cpp
@@ -156,12 +156,11 @@ void Supernova<ndim>::SupernovaInjection
     for (k=0; k<ndim; k++) vpart[k] = (rpart[k] - SNpos[k])/drmag * vrad_mag;
 
     // Get new particle i
-    Particle<ndim> &part = hydro->CreateNewParticle(gas, gas_type, n, level_step, level_max,
-                                                    t, hydro->mmean, uinj, rpart, vpart,sim);
+    Particle<ndim> &part = hydro->CreateNewParticle
+      (gas, gas_type, hydro->mmean, uinj, rpart, vpart, sim);
 
-    // Set SNid?
-    // Set smoothing length?
   }
+  //-----------------------------------------------------------------------------------------------
 
 
   delete[] pos;

--- a/src/Feedback/Supernova.cpp
+++ b/src/Feedback/Supernova.cpp
@@ -84,6 +84,11 @@ void Supernova<ndim>::SupernovaInjection
   FLOAT uinj;                                // internal energy to be added to the particles [code units u = erg/g]
   int *neiblist = new int[Nneibmax];         // ..
 
+#ifdef MPI_PARALLEL
+  string message = "Supernova injection currently not working with MPI!";
+  ExceptionHandler::getIstance().raise(message);
+#endif
+
   // Randomly draw the new position within Rinj
   pos = new FLOAT[ndim*Ninject];
   Ic<ndim>::AddRandomSphere(Ninject, SNpos, Rinj, pos, randnumb);

--- a/src/Feedback/Supernova.cpp
+++ b/src/Feedback/Supernova.cpp
@@ -124,16 +124,20 @@ void Supernova<ndim>::SupernovaInjection
 
   // Total number of hot SN particles = new particles + existing particles within sphere
   nSNinject = Ninject + Nneib;
+
+#ifdef OUTPUT_ALL
   cout << "Adding " << Ninject << " new particles.  Heating " << Nneib << " other particles" << endl;
   cout << "Rinj : " << Rinj << endl;
+#endif
 
   // Give the particles their radial velocities
   vrad_mag = sqrt(2./( (FLOAT) nSNinject)/(hydro->mmean)*Einj*1./(R_therm_kin+1.));
   etherm_mag = (1.0/(1.0 + 1.0/R_therm_kin))*Einj/( (FLOAT) nSNinject);
   uinj = etherm_mag/(hydro->mmean);
+#ifdef OUTPUT_ALL
   cout << "etot : " << (1.0/(1.0 + 1.0/R_therm_kin))*Einj
        << "    etherm_mag : " << etherm_mag << "     uinj : " << uinj << endl;
-
+#endif
 
   // Loop over existing particles and accelerate them
   //-----------------------------------------------------------------------------------------------

--- a/src/Feedback/SupernovaDriver.cpp
+++ b/src/Feedback/SupernovaDriver.cpp
@@ -76,7 +76,9 @@ void SedovTestDriver<ndim>::Update
   // Create supernova at requested time (and ensure that only one is made)
   //-----------------------------------------------------------------------------------------------
   if (Nsupernova == 0 && t >= tsupernova) {
-    //cout << "ADDING SUPERNOVA!!" << endl;
+#ifdef OUTPUT_ALL
+    cout << "ADDING SUPERNOVA!!" << endl;
+#endif
 
     FLOAT SNpos[ndim];
     FLOAT Einj        = (FLOAT) 0.01;
@@ -146,8 +148,10 @@ void RandomSedovTestDriver<ndim>::Update
     supernova.SupernovaInjection(n, level_step, level_max, Nsupernova, t, SNpos, Einj,
                                  R_therm_kin, Minj, Rinj, hydro, neibsearch, randnumb);
     Nsupernova++;
-    cout << "ADDING SUPERNOVA!   Nsupernova : " << Nsupernova << endl;
 
+#ifdef OUTPUT_ALL
+    cout << "ADDING SUPERNOVA!   Nsupernova : " << Nsupernova << endl;
+#endif
     tnext = ((FLOAT) Nsupernova + 0.5)*tsupernova;
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/Feedback/SupernovaDriver.cpp
+++ b/src/Feedback/SupernovaDriver.cpp
@@ -141,7 +141,7 @@ void RandomSedovTestDriver<ndim>::Update
     FLOAT R_therm_kin = (FLOAT) 100000.0;
     FLOAT Minj        = (FLOAT) 0.005;
     FLOAT Rinj        = hydro->GetParticlePointer(0).h; //(FLOAT) 0.0;
-    for (int k=0; k<ndim; k++) SNpos[k] = simbox->boxmin[k] + randnumb->floatrand()*simbox->boxsize[k];
+    for (int k=0; k<ndim; k++) SNpos[k] = simbox->min[k] + randnumb->floatrand()*simbox->size[k];
 
     supernova.SupernovaInjection(n, level_step, level_max, Nsupernova, t, SNpos, Einj,
                                  R_therm_kin, Minj, Rinj, hydro, neibsearch, randnumb);

--- a/src/Feedback/SupernovaDriver.cpp
+++ b/src/Feedback/SupernovaDriver.cpp
@@ -134,7 +134,7 @@ void RandomSedovTestDriver<ndim>::Update
   RandomNumber *randnumb)                    ///< Pointer to random number generator
 {
 
-  // Use random number generator to decide if new supernova should be created or not
+  // Use random number generator to decide the position of the supernova
   //-----------------------------------------------------------------------------------------------
   if (t >= tnext) {
 

--- a/src/Feedback/SupernovaDriver.cpp
+++ b/src/Feedback/SupernovaDriver.cpp
@@ -76,8 +76,7 @@ void SedovTestDriver<ndim>::Update
   // Create supernova at requested time (and ensure that only one is made)
   //-----------------------------------------------------------------------------------------------
   if (Nsupernova == 0 && t >= tsupernova) {
-
-    cout << "ADDING SUPERNOVA!!" << endl;
+    //cout << "ADDING SUPERNOVA!!" << endl;
 
     FLOAT SNpos[ndim];
     FLOAT Einj        = (FLOAT) 0.01;
@@ -96,6 +95,73 @@ void SedovTestDriver<ndim>::Update
 }
 
 
+
+
+//=================================================================================================
+//  RandomSedovTestDriver::SedovTestDriver
+/// ...
+//=================================================================================================
+template <int ndim>
+RandomSedovTestDriver<ndim>::RandomSedovTestDriver
+ (Parameters *params, SimUnits &units, DomainBox<ndim> &_simbox) : SupernovaDriver<ndim>()
+{
+  // Local references to parameter variables for brevity
+  map<string, int> &intparams = params->intparams;
+  map<string, double> &floatparams = params->floatparams;
+  map<string, string> &stringparams = params->stringparams;
+
+  tsupernova = 0.5;
+  tnext = 0.5*tsupernova;
+  simbox = &(_simbox);
+}
+
+
+
+//=================================================================================================
+//  SedovTestDriver::Update
+/// ...
+//=================================================================================================
+template <int ndim>
+void RandomSedovTestDriver<ndim>::Update
+ (const int n,                               ///< Current integer time
+  const int level_step,                      ///< ..
+  const int level_max,                       ///< Max. block timestep level
+  const FLOAT t,                             ///< Physical simulation time
+  Hydrodynamics<ndim> *hydro,                ///< Pointer to hydrodynamics object
+  NeighbourSearch<ndim> *neibsearch,         ///< Pointer to neighbour search object
+  RandomNumber *randnumb)                    ///< Pointer to random number generator
+{
+
+  // Use random number generator to decide if new supernova should be created or not
+  //-----------------------------------------------------------------------------------------------
+  if (t >= tnext) {
+
+    FLOAT SNpos[ndim];
+    FLOAT Einj        = (FLOAT) 0.01;
+    FLOAT R_therm_kin = (FLOAT) 100000.0;
+    FLOAT Minj        = (FLOAT) 0.005;
+    FLOAT Rinj        = hydro->GetParticlePointer(0).h; //(FLOAT) 0.0;
+    for (int k=0; k<ndim; k++) SNpos[k] = simbox->boxmin[k] + randnumb->floatrand()*simbox->boxsize[k];
+
+    supernova.SupernovaInjection(n, level_step, level_max, Nsupernova, t, SNpos, Einj,
+                                 R_therm_kin, Minj, Rinj, hydro, neibsearch, randnumb);
+    Nsupernova++;
+    cout << "ADDING SUPERNOVA!   Nsupernova : " << Nsupernova << endl;
+
+    tnext = ((FLOAT) Nsupernova + 0.5)*tsupernova;
+  }
+  //-----------------------------------------------------------------------------------------------
+
+  return;
+}
+
+
+
 template class SedovTestDriver<1>;
+template class RandomSedovTestDriver<1>;
+
 template class SedovTestDriver<2>;
+template class RandomSedovTestDriver<2>;
+
 template class SedovTestDriver<3>;
+template class RandomSedovTestDriver<3>;

--- a/src/Feedback/SupernovaDriver.cpp
+++ b/src/Feedback/SupernovaDriver.cpp
@@ -1,0 +1,109 @@
+//=================================================================================================
+//  SupernovaDriver.cpp
+//  Routines for creating supernova explosions in GANDALF simulations.
+//
+//  This file is part of GANDALF :
+//  Graphical Astrophysics code for N-body Dynamics And Lagrangian Fluids
+//  https://github.com/gandalfcode/gandalf
+//  Contact : gandalfcode@gmail.com
+//
+//  Copyright (C) 2013  D. A. Hubber, G. Rosotti
+//
+//  GANDALF is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  GANDALF is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License (http://www.gnu.org/licenses) for more details.
+//=================================================================================================
+
+
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+#include <math.h>
+#include "Constants.h"
+#include "Precision.h"
+#include "NbodyParticle.h"
+#include "StarParticle.h"
+#include "Parameters.h"
+#include "Sph.h"
+#include "Nbody.h"
+#include "Sinks.h"
+#include "Debug.h"
+#include "Exception.h"
+#include "InlineFuncs.h"
+using namespace std;
+
+
+
+//=================================================================================================
+//  ...
+/// SupernovaDriving class constructor
+// For now this class treats the Supernova driving from an external file
+//=================================================================================================
+template <int ndim>
+SedovTestDriver<ndim>::SedovTestDriver
+ (Parameters *params, SimUnits &units, bool restart, FLOAT time) : SupernovaDriver()
+{
+  // Local references to parameter variables for brevity
+  map<string, int> &intparams = params->intparams;
+  map<string, double> &floatparams = params->floatparams;
+  map<string, string> &stringparams = params->stringparams;
+
+  tsupernova = 1.0;
+}
+
+
+
+//=================================================================================================
+//  SedovTestDriver::Update
+/// ...
+//=================================================================================================
+template <int ndim>
+void SedovTestDriver<ndim>::Update
+ (int n,                                     ///< Current integer time
+  int level_max,                             ///< Max. block timestep level
+  FLOAT t,                                   ///< Physical simulation time
+  Hydrodynamics<ndim> *hydro,                ///< Pointer to hydrodynamics object
+  NeighbourSearch<ndim> *neibsearch,         ///< Pointer to neighbour search object
+  RandomNumber *randnumb)                    ///< Pointer to random number generator
+{
+
+  FLOAT SNpos[ndim];  //current Supernova position
+  FLOAT Einj;         //total energy of SN (default 1e51 erg)
+
+    // Helper variables (local)
+  FLOAT t_ratio1;
+
+
+  if (SNid == -1) {
+    cout << "Welcome, this is your first Supernova!";
+    SNid =0;
+  }
+
+  // get last SN from table
+  t_ratio1 = SNtime[SNid]/time;
+
+
+  // check if a Supernova should be injected:
+  while (t_ratio1<= 1.){
+    // inject SN now!...
+    cout << "Injecting SN number "<< SNid;
+
+    // Fill entries to pass to SupernovaInjection
+    SNpos[0]=SNposx[SNid];
+    SNpos[1]=SNposy[SNid];
+    SNpos[2]=SNposz[SNid];
+    Einj = SNEinj[SNid];
+
+  supernova.SupernovaInjection(SNpos, Einj, R_therm_kin, Minj, Rinj, SNid, hydro);
+
+
+  //return
+}

--- a/src/Feedback/SupernovaDriver.cpp
+++ b/src/Feedback/SupernovaDriver.cpp
@@ -46,7 +46,7 @@ using namespace std;
 //=================================================================================================
 template <int ndim>
 SedovTestDriver<ndim>::SedovTestDriver
- (Parameters *params, SimUnits &units) : SupernovaDriver<ndim>()
+ (SimulationBase* sim, Parameters *params, SimUnits &units) : SupernovaDriver<ndim>(sim)
 {
   // Local references to parameter variables for brevity
   map<string, int> &intparams = params->intparams;
@@ -105,7 +105,7 @@ void SedovTestDriver<ndim>::Update
 //=================================================================================================
 template <int ndim>
 RandomSedovTestDriver<ndim>::RandomSedovTestDriver
- (Parameters *params, SimUnits &units, DomainBox<ndim> &_simbox) : SupernovaDriver<ndim>()
+ (SimulationBase* sim, Parameters *params, SimUnits &units, DomainBox<ndim> &_simbox) : SupernovaDriver<ndim>(sim)
 {
   // Local references to parameter variables for brevity
   map<string, int> &intparams = params->intparams;

--- a/src/GradhSph/GradhSph.cpp
+++ b/src/GradhSph/GradhSph.cpp
@@ -261,7 +261,7 @@ int GradhSph<ndim, kernelclass>::ComputeH
 
     // Density must at least equal its self-contribution
     // (failure could indicate neighbour list problem)
-    assert(parti.rho >= parti.m*parti.hfactor*kern.w0(0.0));
+    assert(parti.rho >= (FLOAT) 0.999*parti.m*parti.hfactor*kern.w0(0.0));
 
     FLOAT invrho = 0 ;
     if (parti.rho > (FLOAT) 0.0) invrho = (FLOAT) 1.0/parti.rho;

--- a/src/GradhSph/GradhSph.cpp
+++ b/src/GradhSph/GradhSph.cpp
@@ -97,7 +97,7 @@ void GradhSph<ndim, kernelclass>::AllocateMemory(int N)
       delete[] newsphdata;
     }
 
-	Nhydromax=N;
+    Nhydromax=N;
     allocated        = true;
     hydrodata_unsafe = sphdata;
     sphdata_unsafe   = sphdata;

--- a/src/Headers/Hydrodynamics.h
+++ b/src/Headers/Hydrodynamics.h
@@ -84,7 +84,7 @@ public:
   void CheckBoundaryGhostParticle(const int, const int, const FLOAT, const DomainBox<ndim> &);
 
   void CreateBoundaryGhostParticle(const int, const int, const int, const FLOAT, const FLOAT);
-  Particle<ndim>& CreateNewParticle(const enum ptype, const enum parttype, const int, const int,
+  Particle<ndim>& CreateNewParticle(const enum ptype, const enum parttype, const int, const int, const int,
                                     const FLOAT, const FLOAT, const FLOAT, const FLOAT*, const FLOAT*);
 
 

--- a/src/Headers/Hydrodynamics.h
+++ b/src/Headers/Hydrodynamics.h
@@ -84,6 +84,9 @@ public:
   void CheckBoundaryGhostParticle(const int, const int, const FLOAT, const DomainBox<ndim> &);
 
   void CreateBoundaryGhostParticle(const int, const int, const int, const FLOAT, const FLOAT);
+  Particle<ndim>& CreateNewParticle(const enum ptype, const enum parttype, const int, const int,
+                                    const FLOAT, const FLOAT, const FLOAT, const FLOAT*, const FLOAT*);
+
 
 
   // Functions needed to hide some implementation details
@@ -112,6 +115,7 @@ public:
   //-----------------------------------------------------------------------------------------------
   bool allocated;                      ///< Is memory allocated?
   int create_sinks;                    ///< Create new sink particles?
+  bool newParticles;                   ///< Have new ptcls been added? If so, flag to rebuild tree
   int Ngather;                         ///< No. of gather neighbours
   int Nghost;                          ///< No. of ghost particles (total among all kinds of ghosts)
   int NImportedParticles;              ///< No. of imported particles

--- a/src/Headers/Hydrodynamics.h
+++ b/src/Headers/Hydrodynamics.h
@@ -47,6 +47,8 @@ using namespace std;
 template <int ndim>
 class EOS;
 
+class SimulationBase;
+
 static const FLOAT ghost_range = 2.5;
 
 
@@ -85,7 +87,7 @@ public:
 
   void CreateBoundaryGhostParticle(const int, const int, const int, const FLOAT, const FLOAT);
   Particle<ndim>& CreateNewParticle(const enum ptype, const enum parttype, const int, const int, const int,
-                                    const FLOAT, const FLOAT, const FLOAT, const FLOAT*, const FLOAT*);
+                                    const FLOAT, const FLOAT, const FLOAT, const FLOAT*, const FLOAT*,SimulationBase*);
 
 
 
@@ -115,7 +117,6 @@ public:
   //-----------------------------------------------------------------------------------------------
   bool allocated;                      ///< Is memory allocated?
   int create_sinks;                    ///< Create new sink particles?
-  bool newParticles;                   ///< Have new ptcls been added? If so, flag to rebuild tree
   int Ngather;                         ///< No. of gather neighbours
   int Nghost;                          ///< No. of ghost particles (total among all kinds of ghosts)
   int NImportedParticles;              ///< No. of imported particles

--- a/src/Headers/Hydrodynamics.h
+++ b/src/Headers/Hydrodynamics.h
@@ -86,8 +86,8 @@ public:
   void CheckBoundaryGhostParticle(const int, const int, const FLOAT, const DomainBox<ndim> &);
 
   void CreateBoundaryGhostParticle(const int, const int, const int, const FLOAT, const FLOAT);
-  Particle<ndim>& CreateNewParticle(const enum ptype, const enum parttype, const int, const int, const int,
-                                    const FLOAT, const FLOAT, const FLOAT, const FLOAT*, const FLOAT*,SimulationBase*);
+  Particle<ndim>& CreateNewParticle(const enum ptype, const enum parttype, const FLOAT,
+                                    const FLOAT, const FLOAT*, const FLOAT*,SimulationBase*);
 
 
 

--- a/src/Headers/IC.h
+++ b/src/Headers/IC.h
@@ -117,8 +117,8 @@ public:
   // Static functions which can be used outside of Ic class
   // (e.g. generating new particles on the fly in simulations)
   //-----------------------------------------------------------------------------------------------
-  static void AddCubicLattice(const int, const int *, const DomainBox<ndim>, const bool, FLOAT *);
-  static void AddHexagonalLattice(const int, const int *, const DomainBox<ndim>, const bool, FLOAT *);
+  static void AddCubicLattice(const int, const int *, const DomainBox<ndim> &, const bool, FLOAT *);
+  static void AddHexagonalLattice(const int, const int *, const DomainBox<ndim> &, const bool, FLOAT *);
   static int AddLatticeSphere(const int, const FLOAT *, const FLOAT, const string, FLOAT *, RandomNumber *);
   static void AddRandomBox(const int, const DomainBox<ndim>, FLOAT *, RandomNumber *);
   static void AddRandomSphere(const int, const FLOAT *, const FLOAT, FLOAT *, RandomNumber *);

--- a/src/Headers/IC.h
+++ b/src/Headers/IC.h
@@ -67,7 +67,7 @@ private:
   int AddLatticeSphere(const int, const FLOAT *, const FLOAT, const string, FLOAT *);
   void AddRotationalVelocityField(const int, const FLOAT, const FLOAT *, const FLOAT *, FLOAT *);
   void AddRandomBox(const int, const DomainBox<ndim>, FLOAT *);
-  void AddRandomSphere(const int, const FLOAT *, const FLOAT, FLOAT *);
+  //static void AddRandomSphere(const int, const FLOAT *, const FLOAT, FLOAT *, RandomNumber *);
   void Addr2Sphere(int, FLOAT *, FLOAT *, FLOAT);
   void AddSinusoidalDensityPerturbation(int, FLOAT, FLOAT, FLOAT *);
   int CutSphere(const int, const int, const DomainBox<ndim>, const bool, FLOAT *);
@@ -119,6 +119,8 @@ public:
   void TurbIsothermSphere(void);
   void EvrardCollapse(void);
   void DustyBox(void);
+
+  static void AddRandomSphere(const int, const FLOAT *, const FLOAT, FLOAT *, RandomNumber *);
 
 };
 #endif

--- a/src/Headers/IC.h
+++ b/src/Headers/IC.h
@@ -62,15 +62,9 @@ private:
   void AddAzimuthalDensityPerturbation(const int, const int, const FLOAT, const FLOAT *, FLOAT *);
   void AddBinaryStar(FLOAT, FLOAT, FLOAT, FLOAT, FLOAT, FLOAT, FLOAT, FLOAT, FLOAT, FLOAT,
                      FLOAT *, FLOAT *, NbodyParticle<ndim> &, NbodyParticle<ndim> &);
-  void AddCubicLattice(const int, const int *, const DomainBox<ndim>&, const bool, FLOAT *);
-  void AddHexagonalLattice(const int, const int *, const DomainBox<ndim>&, const bool, FLOAT *);
-  int AddLatticeSphere(const int, const FLOAT *, const FLOAT, const string, FLOAT *);
   void AddRotationalVelocityField(const int, const FLOAT, const FLOAT *, const FLOAT *, FLOAT *);
-  void AddRandomBox(const int, const DomainBox<ndim>, FLOAT *);
-  //static void AddRandomSphere(const int, const FLOAT *, const FLOAT, FLOAT *, RandomNumber *);
   void Addr2Sphere(int, FLOAT *, FLOAT *, FLOAT);
   void AddSinusoidalDensityPerturbation(int, FLOAT, FLOAT, FLOAT *);
-  int CutSphere(const int, const int, const DomainBox<ndim>, const bool, FLOAT *);
   void ComputeBondiSolution(int, FLOAT *, FLOAT *, FLOAT *, FLOAT *);
   void GenerateTurbulentVelocityField(const int, const int, const DOUBLE, DOUBLE *);
   void InterpolateVelocityField(const int, const int, const FLOAT, const FLOAT,
@@ -79,10 +73,10 @@ private:
 
 public:
 
-  Ic(Simulation<ndim>* sim_aux, Hydrodynamics<ndim>* hydro_aux, FLOAT invndim_aux) :
-    sim(sim_aux), hydro(hydro_aux), invndim(invndim_aux),
-    simunits(sim_aux->simunits), simbox(sim_aux->simbox),
-    simparams(sim_aux->simparams), randnumb(sim_aux->randnumb)
+  Ic(Simulation<ndim>* _sim, Hydrodynamics<ndim>* _hydro, FLOAT _invndim) :
+    sim(_sim), hydro(_hydro), invndim(_invndim),
+    simunits(_sim->simunits), simbox(_sim->simbox),
+    simparams(_sim->simparams), randnumb(_sim->randnumb)
   {
   };
 
@@ -120,7 +114,15 @@ public:
   void EvrardCollapse(void);
   void DustyBox(void);
 
+  // Static functions which can be used outside of Ic class
+  // (e.g. generating new particles on the fly in simulations)
+  //-----------------------------------------------------------------------------------------------
+  static void AddCubicLattice(const int, const int *, const DomainBox<ndim>, const bool, FLOAT *);
+  static void AddHexagonalLattice(const int, const int *, const DomainBox<ndim>, const bool, FLOAT *);
+  static int AddLatticeSphere(const int, const FLOAT *, const FLOAT, const string, FLOAT *, RandomNumber *);
+  static void AddRandomBox(const int, const DomainBox<ndim>, FLOAT *, RandomNumber *);
   static void AddRandomSphere(const int, const FLOAT *, const FLOAT, FLOAT *, RandomNumber *);
+  static int CutSphere(const int, const int, const DomainBox<ndim>, const bool, FLOAT *);
 
 };
 #endif

--- a/src/Headers/Nbody.h
+++ b/src/Headers/Nbody.h
@@ -29,6 +29,8 @@
 #include "Precision.h"
 #include "CodeTiming.h"
 #include "Constants.h"
+#include "DomainBox.h"
+#include "Ewald.h"
 #include "ExternalPotential.h"
 #include "Hydrodynamics.h"
 #include "Parameters.h"
@@ -79,7 +81,8 @@ class Nbody
   //-----------------------------------------------------------------------------------------------
   virtual void AdvanceParticles(int, int, FLOAT, FLOAT, NbodyParticle<ndim> **) = 0;
   virtual void CalculateAllStartupQuantities(int, NbodyParticle<ndim> **) = 0;
-  virtual void CalculateDirectSmoothedGravForces(int, NbodyParticle<ndim> **) = 0;
+  virtual void CalculateDirectSmoothedGravForces(int, NbodyParticle<ndim> **,
+                                                 DomainBox<ndim> &, Ewald<ndim> *) = 0;
   virtual void CalculateDirectHydroForces(NbodyParticle<ndim> *, int, int,
                                           int *, int *, Hydrodynamics<ndim> *) = 0;
   virtual void CalculatePerturberForces(int, int, NbodyParticle<ndim> **,
@@ -168,7 +171,7 @@ public:
 
   void AdvanceParticles(int, int, FLOAT, FLOAT, NbodyParticle<ndim> **);
   void CalculateAllStartupQuantities(int, NbodyParticle<ndim> **) {};
-  void CalculateDirectSmoothedGravForces(int, NbodyParticle<ndim> **);
+  void CalculateDirectSmoothedGravForces(int, NbodyParticle<ndim> **, DomainBox<ndim> &, Ewald<ndim> *);
   void CalculateDirectHydroForces(NbodyParticle<ndim> *, int, int,
                                   int *, int *, Hydrodynamics<ndim> *);
   void CorrectionTerms(int, int, FLOAT, FLOAT, NbodyParticle<ndim> **);
@@ -206,7 +209,7 @@ public:
 
   void AdvanceParticles(int, int, FLOAT, FLOAT, NbodyParticle<ndim> **);
   void CalculateAllStartupQuantities(int, NbodyParticle<ndim> **) {};
-  void CalculateDirectSmoothedGravForces(int, NbodyParticle<ndim> **);
+  void CalculateDirectSmoothedGravForces(int, NbodyParticle<ndim> **, DomainBox<ndim> &, Ewald<ndim> *);
   void CalculateDirectHydroForces(NbodyParticle<ndim> *, int, int,
                                   int *, int *, Hydrodynamics<ndim> *);
   void CorrectionTerms(int, int, FLOAT, FLOAT, NbodyParticle<ndim> **) {};
@@ -246,7 +249,7 @@ public:
 
   void AdvanceParticles(int, int, FLOAT, FLOAT, NbodyParticle<ndim> **);
   void CalculateAllStartupQuantities(int, NbodyParticle<ndim> **);
-  void CalculateDirectSmoothedGravForces(int, NbodyParticle<ndim> **);
+  void CalculateDirectSmoothedGravForces(int, NbodyParticle<ndim> **, DomainBox<ndim> &, Ewald<ndim> *);
   void CalculateDirectHydroForces(NbodyParticle<ndim> *, int, int,
                                   int *, int *, Hydrodynamics<ndim> *);
   void CorrectionTerms(int, int, FLOAT, FLOAT, NbodyParticle<ndim> **);
@@ -320,7 +323,7 @@ public:
   void CalculateDirectGravForces(int, NbodyParticle<ndim> **);
   void AdvanceParticles(int, int, FLOAT, FLOAT, NbodyParticle<ndim> **);
   void CalculateAllStartupQuantities(int, NbodyParticle<ndim> **);
-  void CalculateDirectSmoothedGravForces(int, NbodyParticle<ndim> **);
+  void CalculateDirectSmoothedGravForces(int, NbodyParticle<ndim> **, DomainBox<ndim> &, Ewald<ndim> *);
   void CalculateDirectHydroForces(NbodyParticle<ndim> *, int, int,
                                   int *, int *, Hydrodynamics<ndim> *);
   void CorrectionTerms(int, int, FLOAT, FLOAT, NbodyParticle<ndim> **);

--- a/src/Headers/Simulation.h
+++ b/src/Headers/Simulation.h
@@ -39,20 +39,27 @@
 #include "Diagnostics.h"
 #include "DomainBox.h"
 #include "Dust.h"
+#include "EnergyEquation.h"
 #include "Ewald.h"
 #include "ExternalPotential.h"
+#include "Ghosts.h"
+#include "HeaderInfo.h"
 #include "Hydrodynamics.h"
 #include "MeshlessFV.h"
 #include "MfvNeighbourSearch.h"
+#include "Nbody.h"
+#include "NbodySystemTree.h"
 #include "Precision.h"
 #include "Parameters.h"
 #include "Radiation.h"
 #include "RandomNumber.h"
 #include "SimUnits.h"
+#include "Sinks.h"
 #include "SmoothingKernel.h"
 #include "Sph.h"
 #include "SphNeighbourSearch.h"
 #include "SphIntegration.h"
+#include "Supernova.h"
 #include "TreeRay.h"
 #include "EnergyEquation.h"
 #include "Nbody.h"
@@ -301,6 +308,7 @@ class Simulation : public SimulationBase
   Sinks<ndim> *sinks;                  ///< Sink particle object
   SphIntegration<ndim> *sphint;        ///< SPH Integration scheme pointer
   SphNeighbourSearch<ndim> *sphneib;   ///< SPH Neighbour scheme pointer
+  SupernovaDriver<ndim> *snDriver;     ///< Supernova feedback driver
 #ifdef MPI_PARALLEL
   MpiControl<ndim>* mpicontrol;        ///< MPI control object
   Ghosts<ndim>* MpiGhosts;             ///< MPI ghost particle object
@@ -390,6 +398,7 @@ class SphSimulation : public Simulation<ndim>
   using Simulation<ndim>::ntreebuildstep;
   using Simulation<ndim>::ntreestockstep;
   using Simulation<ndim>::tmax_wallclock;
+  using Simulation<ndim>::snDriver;
   using Simulation<ndim>::sphneib;
   using Simulation<ndim>::radiation;
 #ifdef MPI_PARALLEL

--- a/src/Headers/Simulation.h
+++ b/src/Headers/Simulation.h
@@ -644,6 +644,7 @@ class MeshlessFVSimulation : public Simulation<ndim>
   using Simulation<ndim>::ntreestockstep;
   using Simulation<ndim>::tmax_wallclock;
   using Simulation<ndim>::radiation;
+  using Simulation<ndim>::snDriver;
 #ifdef MPI_PARALLEL
   using Simulation<ndim>::mpicontrol;
   using Simulation<ndim>::MpiGhosts;
@@ -738,6 +739,7 @@ class MfvMusclSimulation : public MeshlessFVSimulation<ndim>
   using Simulation<ndim>::ntreestockstep;
   using Simulation<ndim>::tmax_wallclock;
   using Simulation<ndim>::radiation;
+  using Simulation<ndim>::snDriver;
   using MeshlessFVSimulation<ndim>::mfv;
   using MeshlessFVSimulation<ndim>::mfvneib;
 #ifdef MPI_PARALLEL

--- a/src/Headers/Simulation.h
+++ b/src/Headers/Simulation.h
@@ -60,14 +60,8 @@
 #include "SphNeighbourSearch.h"
 #include "SphIntegration.h"
 #include "Supernova.h"
-#include "TreeRay.h"
-#include "EnergyEquation.h"
-#include "Nbody.h"
-#include "NbodySystemTree.h"
-#include "Ghosts.h"
-#include "Sinks.h"
-#include "HeaderInfo.h"
 #include "TimeStepControl.h"
+#include "TreeRay.h"
 using namespace std;
 #ifdef MPI_PARALLEL
 #include "mpi.h"

--- a/src/Headers/Supernova.h
+++ b/src/Headers/Supernova.h
@@ -30,6 +30,7 @@
 #include <string>
 #include "Precision.h"
 #include "Constants.h"
+#include "DomainBox.h"
 #include "Hydrodynamics.h"
 #include "NeighbourSearch.h"
 #include "Particle.h"
@@ -123,6 +124,34 @@ public:
 
   SedovTestDriver(Parameters *params, SimUnits &units);
   ~SedovTestDriver();
+
+  virtual void Update(const int, const int, const int, const FLOAT,
+                      Hydrodynamics<ndim> *, NeighbourSearch<ndim> *, RandomNumber *);
+
+};
+
+
+
+//=================================================================================================
+//  Class RandomSedovTestDriver
+/// \brief   Random supernova driver to test multiple explosion with block timesteps.
+/// \details Random supernova driver to test multiple explosion with block timesteps.
+/// \author  D. A. Hubber
+/// \date    06/09/2016
+//=================================================================================================
+template <int ndim>
+class RandomSedovTestDriver : public SupernovaDriver<ndim>
+{
+public:
+  using SupernovaDriver<ndim>::Nsupernova;
+
+  FLOAT tnext;                                   ///< Time for next supernova explosion
+  FLOAT tsupernova;                              ///< Average time inbetween supernovae
+  Supernova<ndim> supernova;                     ///< Instance of supernova class
+  DomainBox<ndim> *simbox;                       ///< Pointer to simulation domain box
+
+  RandomSedovTestDriver(Parameters *params, SimUnits &units, DomainBox<ndim> &);
+  ~RandomSedovTestDriver();
 
   virtual void Update(const int, const int, const int, const FLOAT,
                       Hydrodynamics<ndim> *, NeighbourSearch<ndim> *, RandomNumber *);

--- a/src/Headers/Supernova.h
+++ b/src/Headers/Supernova.h
@@ -55,4 +55,88 @@ public:
                           Hydrodynamics<ndim> *, NeighbourSearch<ndim> *, RandomNumber *);
 
 };
+
+
+
+//=================================================================================================
+//  Class SupernovaDriver
+/// \brief   Main parent Supernova class
+/// \details Injects a single Supernova; adds accelerated particles within injection radius
+/// \author  S. Walch, D. A. Hubber
+/// \date    19/01/2016
+//=================================================================================================
+template <int ndim>
+class SupernovaDriver
+{
+public:
+
+  int Nsupernova;                      ///< ..
+
+  //SupernovaDriver(Parameters *params, SimUnits &units, bool restart, FLOAT time);
+  SupernovaDriver() {Nsupernova = 0;}
+  ~SupernovaDriver() {};
+
+  void Update(FLOAT, Hydrodynamics *) = 0;
+
+};
+
+
+
+//=================================================================================================
+//  Class SedovTestDriver
+/// \brief   Simple Sedov-explosion driver for testing fidelity of explosions
+/// \details Simple Sedov-explosion driver for testing fidelity of explosions
+/// \author  D. A. Hubber
+/// \date    10/02/2016
+//=================================================================================================
+template <int ndim>
+class SedovTestDriver : public SupernovaDriver<ndim>
+{
+public:
+
+  Supernova supernova;                 ///< ..
+  FLOAT tsupernova;
+
+  SedovTestDriver(Parameters *params, SimUnits &units, bool restart, FLOAT time);
+  ~SedovTestDriver();
+
+  void Update(FLOAT, Hydrodynamics<ndim> *);
+
+};
+
+
+
+//=================================================================================================
+//  Class SilccSupernovaDriver
+/// \brief   Main parent SupernovaDriving class
+/// \details ..
+/// \author  D. A. Hubber, S. Walch, T. Balduin, P. Rohde
+/// \date    19/01/2016
+//=================================================================================================
+/*template <int ndim>
+class SilccSupernovaDriving
+{
+public:
+  // SN ID (defined in constructor)
+  int SNid;
+
+  // Global SN parameters that could go into the parameters file
+  FLOAT R_therm_kin;  //ratio of thermal and kinetic E to be injected
+  FLOAT Minj;         //ejecta mass (default 7 Msun)
+  FLOAT Rinj;         //injection radius (default 1pc)
+
+  int nSN;
+  FLOAT *SNtime;
+  FLOAT *SNposx;
+  FLOAT *SNposy;
+  FLOAT *SNposz;
+  FLOAT *SNEinj;
+
+
+  // Constructor
+  SupernovaDriving(Parameters *params, SimUnits &units, bool restart, FLOAT time);
+  // update pass current simulation time, time step, hydro
+  void Update(FLOAT, Hydrodynamics*);
+
+};*/
 #endif

--- a/src/Headers/Supernova.h
+++ b/src/Headers/Supernova.h
@@ -1,0 +1,58 @@
+//=================================================================================================
+//  Supernova.h
+//  Contains all definitions for classes related to creating Supernova via adding new particles
+//  with a given thermal or kinetic energy input.
+//
+//  This file is part of GANDALF :
+//  Graphical Astrophysics code for N-body Dynamics And Lagrangian Fluids
+//  https://github.com/gandalfcode/gandalf
+//  Contact : gandalfcode@gmail.com
+//
+//  Copyright (C) 2013  D. A. Hubber, G. Rosotti
+//
+//  GANDALF is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  GANDALF is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License (http://www.gnu.org/licenses) for more details.
+//=================================================================================================
+
+
+#ifndef _SUPERNOVA_H_
+#define _SUPERNOVA_H_
+
+
+#include <assert.h>
+#include <string>
+#include "Precision.h"
+#include "Constants.h"
+#include "Hydrodynamics.h"
+#include "NeighbourSearch.h"
+#include "Particle.h"
+
+
+//=================================================================================================
+//  Class Supernova
+/// \brief   Main parent Supernova class
+/// \details Injects a single Supernova; adds accelerated particles within injection radius
+/// \author  S. Walch, D. A. Hubber
+/// \date    19/01/2016
+//=================================================================================================
+template <int ndim>
+class Supernova
+{
+public:
+
+  Supernova();
+  ~Supernova();
+
+  // pass SN position, Einj, Etherm/Ekin, Minj, Rinj, SNid, hydro
+  void SupernovaInjection(int, int, int, FLOAT, FLOAT *, FLOAT, FLOAT, FLOAT, FLOAT,
+                          Hydrodynamics<ndim> *, NeighbourSearch<ndim> *, RandomNumber *);
+
+};
+#endif

--- a/src/Headers/Supernova.h
+++ b/src/Headers/Supernova.h
@@ -146,7 +146,7 @@ public:
   using SupernovaDriver<ndim>::Nsupernova;
 
   FLOAT tnext;                                   ///< Time for next supernova explosion
-  FLOAT tsupernova;                              ///< Average time inbetween supernovae
+  FLOAT tsupernova;                              ///< Time between supernovae
   Supernova<ndim> supernova;                     ///< Instance of supernova class
   DomainBox<ndim> *simbox;                       ///< Pointer to simulation domain box
 

--- a/src/Headers/Supernova.h
+++ b/src/Headers/Supernova.h
@@ -46,10 +46,11 @@
 template <int ndim>
 class Supernova
 {
+	SimulationBase* sim; ///< Pointer to simulation object
 public:
 
-  Supernova();
-  ~Supernova();
+  Supernova(SimulationBase* _sim): sim(_sim) {};
+  ~Supernova() {};
 
   // pass SN position, Einj, Etherm/Ekin, Minj, Rinj, SNid, hydro
   void SupernovaInjection(const int, const int, const int, const int, const FLOAT,
@@ -70,12 +71,15 @@ public:
 template <int ndim>
 class SupernovaDriver
 {
+protected:
+  int Nsupernova;                      ///< Number of supernovae
+  Supernova<ndim>  supernova;                 ///< Supernova object
 public:
 
-  int Nsupernova;                      ///< ..
 
-  //SupernovaDriver(Parameters *params, SimUnits &units, bool restart, FLOAT time);
-  SupernovaDriver() {Nsupernova = 0;}
+
+
+  SupernovaDriver(SimulationBase* sim): supernova(sim) {Nsupernova = 0;}
   ~SupernovaDriver() {};
 
   virtual void Update(const int, const int, const int, const FLOAT, Hydrodynamics<ndim> *, NeighbourSearch<ndim> *, RandomNumber *) = 0;
@@ -96,7 +100,7 @@ class NullSupernovaDriver : public SupernovaDriver<ndim>
 {
 public:
 
-  NullSupernovaDriver() {};
+  NullSupernovaDriver(SimulationBase* sim): SupernovaDriver<ndim>(sim) {};
   ~NullSupernovaDriver() {};
 
   virtual void Update(const int, const int, const int, const FLOAT, Hydrodynamics<ndim> *,
@@ -118,11 +122,11 @@ class SedovTestDriver : public SupernovaDriver<ndim>
 {
 public:
   using SupernovaDriver<ndim>::Nsupernova;
+  using SupernovaDriver<ndim>::supernova;
 
-  Supernova<ndim>  supernova;                 ///< ..
   FLOAT tsupernova;
 
-  SedovTestDriver(Parameters *params, SimUnits &units);
+  SedovTestDriver(SimulationBase* sim, Parameters *params, SimUnits &units);
   ~SedovTestDriver();
 
   virtual void Update(const int, const int, const int, const FLOAT,
@@ -144,13 +148,14 @@ class RandomSedovTestDriver : public SupernovaDriver<ndim>
 {
 public:
   using SupernovaDriver<ndim>::Nsupernova;
+  using SupernovaDriver<ndim>::supernova;
+
 
   FLOAT tnext;                                   ///< Time for next supernova explosion
   FLOAT tsupernova;                              ///< Time between supernovae
-  Supernova<ndim> supernova;                     ///< Instance of supernova class
   DomainBox<ndim> *simbox;                       ///< Pointer to simulation domain box
 
-  RandomSedovTestDriver(Parameters *params, SimUnits &units, DomainBox<ndim> &);
+  RandomSedovTestDriver(SimulationBase* sim, Parameters *params, SimUnits &units, DomainBox<ndim> &);
   ~RandomSedovTestDriver();
 
   virtual void Update(const int, const int, const int, const FLOAT,

--- a/src/Headers/Supernova.h
+++ b/src/Headers/Supernova.h
@@ -51,7 +51,8 @@ public:
   ~Supernova();
 
   // pass SN position, Einj, Etherm/Ekin, Minj, Rinj, SNid, hydro
-  void SupernovaInjection(int, int, int, FLOAT, FLOAT *, FLOAT, FLOAT, FLOAT, FLOAT,
+  void SupernovaInjection(const int, const int, const int, const int, const FLOAT,
+                          FLOAT *, FLOAT, FLOAT, FLOAT, FLOAT,
                           Hydrodynamics<ndim> *, NeighbourSearch<ndim> *, RandomNumber *);
 
 };
@@ -76,7 +77,29 @@ public:
   SupernovaDriver() {Nsupernova = 0;}
   ~SupernovaDriver() {};
 
-  void Update(FLOAT, Hydrodynamics *) = 0;
+  virtual void Update(const int, const int, const int, const FLOAT, Hydrodynamics<ndim> *, NeighbourSearch<ndim> *, RandomNumber *) = 0;
+
+};
+
+
+
+//=================================================================================================
+//  Class NullSupernovaDriver
+/// \brief   ...
+/// \details ...
+/// \author  D. A. Hubber
+/// \date    18/02/2016
+//=================================================================================================
+template <int ndim>
+class NullSupernovaDriver : public SupernovaDriver<ndim>
+{
+public:
+
+  NullSupernovaDriver() {};
+  ~NullSupernovaDriver() {};
+
+  virtual void Update(const int, const int, const int, const FLOAT, Hydrodynamics<ndim> *,
+                      NeighbourSearch<ndim> *, RandomNumber *) {};
 
 };
 
@@ -93,14 +116,16 @@ template <int ndim>
 class SedovTestDriver : public SupernovaDriver<ndim>
 {
 public:
+  using SupernovaDriver<ndim>::Nsupernova;
 
-  Supernova supernova;                 ///< ..
+  Supernova<ndim>  supernova;                 ///< ..
   FLOAT tsupernova;
 
-  SedovTestDriver(Parameters *params, SimUnits &units, bool restart, FLOAT time);
+  SedovTestDriver(Parameters *params, SimUnits &units);
   ~SedovTestDriver();
 
-  void Update(FLOAT, Hydrodynamics<ndim> *);
+  virtual void Update(const int, const int, const int, const FLOAT,
+                      Hydrodynamics<ndim> *, NeighbourSearch<ndim> *, RandomNumber *);
 
 };
 

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -140,9 +140,12 @@ Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
   const FLOAT r[ndim],                 ///< [in] Position of new particle
   const FLOAT v[ndim])                 ///< [in] Velocity of new particle
 {
-  // First, check if there is space for the new particle.  Otherwisr, throw an exception.
+  // First, check if there is space for the new particle.
+  // If not, then increase particle memory by 20% by reallocating arrays.
   if (Nhydro >= Nhydromax) {
-    ExceptionHandler::getIstance().raise("Run out of memory for new hydro particles");
+    const int _Nhydromax = (int) ((FLOAT) 1.2*(FLOAT) Nhydromax);
+    AllocateMemory(_Nhydromax);
+    //ExceptionHandler::getIstance().raise("Run out of memory for new hydro particles");
   }
 
   // Find space for new particle at the end of the array and increment relevant counters.

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -153,8 +153,6 @@ Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
 
   // Set all particle properties from given arguments
   part.iorig     = inew;
-  part.active    = true;
-  part.itype     = _ptype;
   part.ptype     = _parttype;
   part.level     = level_max;
   part.levelneib = level_max;
@@ -173,8 +171,7 @@ Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
   for (int k=0; k<ndim; k++) part.v0[k] = v[k];
   for (int k=0; k<ndim; k++) part.a0[k] = (FLOAT) 0.0;
 
-  //cout << "CREATING NEW PARTICLE : " << inew << "   " << Nhydro << "   m : " << m << "   v : "
-  //     << part.r[0] << "   " << part.r[1] << endl;
+  part.flags.set_flag(active);
 
   return part;
 }

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -34,6 +34,7 @@
 #include "EOS.h"
 #include "Debug.h"
 #include "InlineFuncs.h"
+#include "Simulation.h"
 using namespace std;
 
 
@@ -140,7 +141,8 @@ Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
   const FLOAT m,                       ///< [in] Mass of new particle
   const FLOAT u,                       ///< [in] Specific internal energy of new particle
   const FLOAT r[ndim],                 ///< [in] Position of new particle
-  const FLOAT v[ndim])                 ///< [in] Velocity of new particle
+  const FLOAT v[ndim],                 ///< [in] Velocity of new particle
+  SimulationBase* sim)				   ///< [inout] Simulation object
 {
   // First, check if there is space for the new particle.
   // If not, then increase particle memory by 20% by reallocating arrays.
@@ -150,7 +152,7 @@ Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
   }
 
   // Find space for new particle at the end of the array and increment relevant counters.
-  newParticles = true;
+  sim->rebuild_tree = true;
   int inew = Nhydro++;
   Ntot++;
   Particle<ndim> &part = GetParticlePointer(inew);

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -134,15 +134,11 @@ template <int ndim>
 Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
  (const enum ptype _ptype,             ///< [in] ptype of new particle
   const enum parttype _parttype,       ///< [in] parttype of new particle
-  const int n,                         ///< [in] Current integer time
-  const int level_step,                ///< [in] ..
-  const int level_max,                 ///< [in] Current maximum block timestep level
-  const FLOAT t,                       ///< [in] Current simulation time
   const FLOAT m,                       ///< [in] Mass of new particle
   const FLOAT u,                       ///< [in] Specific internal energy of new particle
   const FLOAT r[ndim],                 ///< [in] Position of new particle
   const FLOAT v[ndim],                 ///< [in] Velocity of new particle
-  SimulationBase* sim)				   ///< [inout] Simulation object
+  SimulationBase* sim)                 ///< [inout] Simulation object
 {
   // First, check if there is space for the new particle.
   // If not, then increase particle memory by 20% by reallocating arrays.
@@ -160,11 +156,11 @@ Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
   // Set all particle properties from given arguments
   part.iorig     = inew;
   part.ptype     = _parttype;
-  part.level     = level_max;
-  part.levelneib = level_max;
-  part.nstep     = pow(2,level_step - part.level);
-  part.nlast     = n - part.nstep;
-  part.tlast     = t;
+  part.level     = sim->level_max;
+  part.levelneib = sim->level_max;
+  part.nstep     = pow(2,sim->level_step - part.level);
+  part.nlast     = sim->n - part.nstep;
+  part.tlast     = sim->t;
   part.m         = m;
   part.h         = (FLOAT) 1.0;
   part.u         = u;

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -173,8 +173,8 @@ Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
   for (int k=0; k<ndim; k++) part.v0[k] = v[k];
   for (int k=0; k<ndim; k++) part.a0[k] = (FLOAT) 0.0;
 
-  cout << "CREATING NEW PARTICLE : " << inew << "   " << Nhydro << "   m : " << m << "   v : "
-       << part.r[0] << "   " << part.r[1] << endl;
+  //cout << "CREATING NEW PARTICLE : " << inew << "   " << Nhydro << "   m : " << m << "   v : "
+  //     << part.r[0] << "   " << part.r[1] << endl;
 
   return part;
 }

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -143,9 +143,8 @@ Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
   // First, check if there is space for the new particle.
   // If not, then increase particle memory by 20% by reallocating arrays.
   if (Nhydro >= Nhydromax) {
-    const int _Nhydromax = (int) ((FLOAT) 1.2*(FLOAT) Nhydromax);
+    const int _Nhydromax = (int) (1.2*Nhydromax);
     AllocateMemory(_Nhydromax);
-    //ExceptionHandler::getIstance().raise("Run out of memory for new hydro particles");
   }
 
   // Find space for new particle at the end of the array and increment relevant counters.

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -123,6 +123,58 @@ Hydrodynamics<ndim>::Hydrodynamics(int hydro_forces_aux, int self_gravity_aux, F
 
 
 //=================================================================================================
+//  Hydrodynamics::CreateNewParticle
+/// Create a new hydro particle in the main arrays at the end of the existing particles.
+/// Also triggers the re-creation of ghosts and another tree-build to include new particles.
+//=================================================================================================
+template <int ndim>
+Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
+ (const enum ptype _ptype,             ///< [in] ptype of new particle
+  const enum parttype _parttype,       ///< [in] parttype of new particle
+  const int n,                         ///< [in] Current integer time
+  const int level_max,                 ///< [in] Current maximum block timestep level
+  const FLOAT t,                       ///< [in] Current simulation time
+  const FLOAT m,                       ///< [in] Mass of new particle
+  const FLOAT u,                       ///< [in] Specific internal energy of new particle
+  const FLOAT r[ndim],                 ///< [in] Position of new particle
+  const FLOAT v[ndim])                 ///< [in] Velocity of new particle
+{
+  // First, check if there is space for the new particle.  Otherwisr, throw an exception.
+  if (Nhydro >= Nhydromax) {
+    ExceptionHandler::getIstance().raise("Run out of memory for new hydro particles");
+  }
+
+  // Find space for new particle at the end of the array and increment relevant counters.
+  newParticles = true;
+  int inew = Nhydro++;
+  Ntot++;
+  Particle<ndim> &part = GetParticlePointer(inew);
+
+  // Set all particle properties from given arguments
+  part.iorig  = -1;
+  part.active = true;
+  part.itype  = _ptype;
+  part.ptype  = _parttype;
+  part.nlast  = n;
+  part.nstep  = 0;
+  part.level  = level_max;
+  part.tlast  = t;
+  part.m      = m;
+  part.u      = u;
+  part.u0     = u;
+  for (int k=0; k<ndim; k++) part.r[k] = r[k];
+  for (int k=0; k<ndim; k++) part.v[k] = v[k];
+  for (int k=0; k<ndim; k++) part.a[k] = (FLOAT) 0.0;
+  for (int k=0; k<ndim; k++) part.r0[k] = r[k];
+  for (int k=0; k<ndim; k++) part.v0[k] = v[k];
+  for (int k=0; k<ndim; k++) part.a0[k] = (FLOAT) 0.0;
+
+  return part;
+}
+
+
+
+//=================================================================================================
 //  Hydrodynamics::ComputeBoundingBox
 /// Calculate the bounding box containing all hydro particles.
 //=================================================================================================

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -132,6 +132,7 @@ Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
  (const enum ptype _ptype,             ///< [in] ptype of new particle
   const enum parttype _parttype,       ///< [in] parttype of new particle
   const int n,                         ///< [in] Current integer time
+  const int level_step,                ///< [in] ..
   const int level_max,                 ///< [in] Current maximum block timestep level
   const FLOAT t,                       ///< [in] Current simulation time
   const FLOAT m,                       ///< [in] Mass of new particle
@@ -151,23 +152,29 @@ Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle
   Particle<ndim> &part = GetParticlePointer(inew);
 
   // Set all particle properties from given arguments
-  part.iorig  = -1;
-  part.active = true;
-  part.itype  = _ptype;
-  part.ptype  = _parttype;
-  part.nlast  = n;
-  part.nstep  = 0;
-  part.level  = level_max;
-  part.tlast  = t;
-  part.m      = m;
-  part.u      = u;
-  part.u0     = u;
+  part.iorig     = inew;
+  part.active    = true;
+  part.itype     = _ptype;
+  part.ptype     = _parttype;
+  part.level     = level_max;
+  part.levelneib = level_max;
+  part.nstep     = pow(2,level_step - part.level);
+  part.nlast     = n - part.nstep;
+  part.tlast     = t;
+  part.m         = m;
+  part.h         = (FLOAT) 1.0;
+  part.u         = u;
+  part.u0        = u;
+  part.dudt      = (FLOAT) 0.0;
   for (int k=0; k<ndim; k++) part.r[k] = r[k];
   for (int k=0; k<ndim; k++) part.v[k] = v[k];
   for (int k=0; k<ndim; k++) part.a[k] = (FLOAT) 0.0;
   for (int k=0; k<ndim; k++) part.r0[k] = r[k];
   for (int k=0; k<ndim; k++) part.v0[k] = v[k];
   for (int k=0; k<ndim; k++) part.a0[k] = (FLOAT) 0.0;
+
+  cout << "CREATING NEW PARTICLE : " << inew << "   " << Nhydro << "   m : " << m << "   v : "
+       << part.r[0] << "   " << part.r[1] << endl;
 
   return part;
 }

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -126,6 +126,8 @@ Hydrodynamics<ndim>::Hydrodynamics(int hydro_forces_aux, int self_gravity_aux, F
 //  Hydrodynamics::CreateNewParticle
 /// Create a new hydro particle in the main arrays at the end of the existing particles.
 /// Also triggers the re-creation of ghosts and another tree-build to include new particles.
+/// Needs to be called soon before the load balancing and tree rebuild because it will invalidate
+/// the tree and the ghosts
 //=================================================================================================
 template <int ndim>
 Particle<ndim>& Hydrodynamics<ndim>::CreateNewParticle

--- a/src/Hydrodynamics/SphIntegration.cpp
+++ b/src/Hydrodynamics/SphIntegration.cpp
@@ -103,15 +103,10 @@ DOUBLE SphIntegration<ndim>::Timestep
     timestep = courant_mult*part.h/(part.h*fabs(part.div_v) + small_number_dp);
   }
 
-  //cout << part.iorig << " " << part.ptype << ", "
-  //		  << part.h << " " <<part.h_dust << " " << part.sound << " " << part.div_v << endl ;
 
-  //cout << timestep << " " ;
   // Acceleration condition
   amag = sqrt(DotProduct(part.a, part.a, ndim));
   timestep = min(timestep, accel_mult*sqrt(part.h/(amag + small_number_dp)));
-
-  //cout << timestep << " " ;
 
 
   // Explicit energy integration timestep condition
@@ -120,8 +115,6 @@ DOUBLE SphIntegration<ndim>::Timestep
         timestep = min(timestep, this->energy_mult*(DOUBLE) (part.u/(fabs(part.dudt) + small_number)));
   }
 
-  //cout << timestep << endl;
-  //cout << "\t" << amag << endl ;
 
   // If stars are included, calculate the timestep due to the jerk
   //adotmag = sqrt(DotProduct(part.adot,part.adot,ndim));
@@ -132,7 +125,7 @@ DOUBLE SphIntegration<ndim>::Timestep
          << part.sound << "    " << part.h*fabs(part.div_v) << endl;
     cout << "tcourant : " << courant_mult*part.h/(part.sound + part.h*fabs(part.div_v) + small_number_dp)
          << "    taccel : " << accel_mult*sqrt(part.h/(amag + small_number_dp))
-         << "    tenergy : " << part.u << endl;
+         << "    tenergy : " << energy_mult*(DOUBLE) (part.u/(fabs(part.dudt) + small_number)) << endl;
     ExceptionHandler::getIstance().raise("Error : Hydro timestep too large");
   }
 

--- a/src/Hydrodynamics/SphIntegration.cpp
+++ b/src/Hydrodynamics/SphIntegration.cpp
@@ -110,9 +110,8 @@ DOUBLE SphIntegration<ndim>::Timestep
 
 
   // Explicit energy integration timestep condition
-  if (gas_eos == energy_eqn) {
-	  if (part.ptype == gas_type)
-        timestep = min(timestep, this->energy_mult*(DOUBLE) (part.u/(fabs(part.dudt) + small_number)));
+  if (gas_eos == energy_eqn && part.ptype == gas_type) {
+    timestep = min(timestep, this->energy_mult*(DOUBLE) (part.u/(fabs(part.dudt) + small_number)));
   }
 
 
@@ -129,8 +128,7 @@ DOUBLE SphIntegration<ndim>::Timestep
     ExceptionHandler::getIstance().raise("Error : Hydro timestep too large");
   }
 
-  assert(!(isnan(amag)) && !(isinf(amag)));
-  assert(!(isnan(timestep)) && !(isinf(timestep)));
+  assert(isfinite(amag) && isfinite(timestep));
 
   return timestep;
 }

--- a/src/Hydrodynamics/SphIntegration.cpp
+++ b/src/Hydrodynamics/SphIntegration.cpp
@@ -127,9 +127,12 @@ DOUBLE SphIntegration<ndim>::Timestep
   //adotmag = sqrt(DotProduct(part.adot,part.adot,ndim));
   //timestep = min(timestep, accel_mult*amag/(adotmag + small_number_dp));
 
-  if (timestep > 1.0e20) {
+  if (timestep > 1.0e20 || timestep < 0.0) {
     cout << "Timestep problem : " << timestep << "   " << amag << "   " << part.h << "    "
          << part.sound << "    " << part.h*fabs(part.div_v) << endl;
+    cout << "tcourant : " << courant_mult*part.h/(part.sound + part.h*fabs(part.div_v) + small_number_dp)
+         << "    taccel : " << accel_mult*sqrt(part.h/(amag + small_number_dp))
+         << "    tenergy : " << part.u << endl;
     ExceptionHandler::getIstance().raise("Error : Hydro timestep too large");
   }
 

--- a/src/Hydrodynamics/SphLeapfrogKDK.cpp
+++ b/src/Hydrodynamics/SphLeapfrogKDK.cpp
@@ -119,6 +119,7 @@ void SphLeapfrogKDK<ndim, ParticleType >::AdvanceParticles
 
     // Flag all dead particles as inactive here
     if (part.flags.is_dead()) part.flags.unset_flag(active);
+
   }
   //-----------------------------------------------------------------------------------------------
 
@@ -216,6 +217,7 @@ void SphLeapfrogKDK<ndim, ParticleType>::EndTimestep
       for (k=0; k<ndim; k++) part.v0[k] = part.v[k];
       for (k=0; k<ndim; k++) part.a0[k] = part.a[k];
       if (gas_eos == energy_eqn) {
+        assert(part.u > 0.0);
         part.u     += 0.5*(part.dudt - part.dudt0)*(t - part.tlast); //timestep*(FLOAT) nstep;
         part.u0    = part.u;
         part.dudt0 = part.dudt;
@@ -224,6 +226,7 @@ void SphLeapfrogKDK<ndim, ParticleType>::EndTimestep
       part.tlast  = t;
       part.flags.unset_flag(active);
     }
+
   }
   //-----------------------------------------------------------------------------------------------
 

--- a/src/Hydrodynamics/SphLeapfrogKDK.cpp
+++ b/src/Hydrodynamics/SphLeapfrogKDK.cpp
@@ -217,7 +217,6 @@ void SphLeapfrogKDK<ndim, ParticleType>::EndTimestep
       for (k=0; k<ndim; k++) part.v0[k] = part.v[k];
       for (k=0; k<ndim; k++) part.a0[k] = part.a[k];
       if (gas_eos == energy_eqn) {
-        assert(part.u > 0.0);
         part.u     += 0.5*(part.dudt - part.dudt0)*(t - part.tlast); //timestep*(FLOAT) nstep;
         part.u0    = part.u;
         part.dudt0 = part.dudt;

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -855,15 +855,16 @@ void SphSimulation<ndim>::MainLoop(void)
   //-----------------------------------------------------------------------------------------------
 
 
-  /* Check that we have sensible smoothing lengths */
+  // Check that we have sensible smoothing lengths
   if (periodicBoundaries) {
     double hmax = sphneib->GetMaximumSmoothingLength() ;
     hmax *= sph->kernp->kernrange ;
-    for (i=0; i < ndim; i++)
-      if (simbox.half[i] < 2*hmax){
-        string message = "Error: Smoothing length too large, self-interaction will occur" ;
-    	ExceptionHandler::getIstance().raise(message);
+    for (int k=0; k<ndim; k++) {
+      if (simbox.half[k] < 2*hmax) {
+        string message = "Error: Smoothing length too large, self-interaction will occur";
+        ExceptionHandler::getIstance().raise(message);
       }
+    }
   }
 
   // Iterate for P(EC)^n schemes for N-body particles
@@ -1144,8 +1145,6 @@ void SphSimulation<ndim>::ComputeBlockTimesteps(void)
     level_max  = Nlevels - 1;
     level_step = level_max + integration_step - 1;
     dt_max     = timestep*powf(2.0, level_max);
-
-    cout << "LEVEL_MAX : " << level_max << "   " << dt_max << "   " << dt_min_hydro << endl;
 
     // Calculate the maximum level occupied by all SPH particles
     level_max_sph   = min(ComputeTimestepLevel(dt_min_hydro, dt_max), level_max);

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -603,7 +603,7 @@ void SphSimulation<ndim>::PostInitialConditionsSetup(void)
   }
 
   if (nbody->nbody_softening == 1) {
-    nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata);
+    nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata, simbox, ewald);
   }
   else {
     nbody->CalculateDirectGravForces(nbody->Nnbody, nbody->nbodydata);
@@ -888,7 +888,7 @@ void SphSimulation<ndim>::MainLoop(void)
 
     // Calculate forces, force derivatives etc.., for active stars/systems
     if (nbody->nbody_softening == 1) {
-      nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody,nbody->nbodydata);
+      nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata, simbox, ewald);
     }
     else {
       nbody->CalculateDirectGravForces(nbody->Nnbody,nbody->nbodydata);

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -238,6 +238,9 @@ void SphSimulation<ndim>::ProcessParameters(void)
   else if (stringparams["supernova_feedback"] == "single") {
     snDriver = new SedovTestDriver<ndim>(simparams, simunits);
   }
+  else if (stringparams["supernova_feedback"] == "random") {
+    snDriver = new RandomSedovTestDriver<ndim>(simparams, simunits, simbox);
+  }
   else {
     string message = "Unrecognised parameter : external_potential = "
       + simparams->stringparams["supernova_feedback"];

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -229,6 +229,22 @@ void SphSimulation<ndim>::ProcessParameters(void)
   }
 #endif
 
+
+  // Supernova feedback
+  //-----------------------------------------------------------------------------------------------
+  if (stringparams["supernova_feedback"] == "none") {
+    snDriver = new NullSupernovaDriver<ndim>();
+  }
+  else if (stringparams["supernova_feedback"] == "single") {
+    snDriver = new SedovTestDriver<ndim>(simparams, simunits);
+  }
+  else {
+    string message = "Unrecognised parameter : external_potential = "
+      + simparams->stringparams["supernova_feedback"];
+    ExceptionHandler::getIstance().raise(message);
+  }
+
+
   // Set other important simulation variables
   dt_litesnap         = floatparams["dt_litesnap"]/simunits.t.outscale;
   dt_python           = floatparams["dt_python"];
@@ -650,8 +666,12 @@ void SphSimulation<ndim>::MainLoop(void)
   sphint->AdvanceParticles(n, sph->Nhydro, (FLOAT) t, (FLOAT) timestep, sph->GetSphParticleArray());
   nbody->AdvanceParticles(n, nbody->Nnbody, t, timestep, nbody->nbodydata);
 
-  // Add any new particles into the simulation here (e.g. Supernova, wind feedback, etc..)
-  if (sph->newParticles) rebuild_tree = true;
+  // Add any new particles into the simulation here (e.g. Supernova, wind feedback, etc..).
+  //-----------------------------------------------------------------------------------------------
+  if (n%(int) pow(2,level_step - level_max) == 0) {
+    snDriver->Update(n, level_step, level_max, t, hydro, sphneib, randnumb);
+    if (sph->newParticles) rebuild_tree = true;
+  }
 
   // Check all boundary conditions
   // (DAVID : Move this function to sphint and create an analagous one
@@ -1122,6 +1142,8 @@ void SphSimulation<ndim>::ComputeBlockTimesteps(void)
     level_step = level_max + integration_step - 1;
     dt_max     = timestep*powf(2.0, level_max);
 
+    cout << "LEVEL_MAX : " << level_max << "   " << dt_max << "   " << dt_min_hydro << endl;
+
     // Calculate the maximum level occupied by all SPH particles
     level_max_sph   = min(ComputeTimestepLevel(dt_min_hydro, dt_max), level_max);
     level_max_nbody = min(ComputeTimestepLevel(dt_min_nbody, dt_max), level_max);
@@ -1435,12 +1457,6 @@ void SphSimulation<ndim>::ComputeBlockTimesteps(void)
 
 
   // Various asserts for debugging
-  assert(timestep >= 0.0 && !(isinf(timestep)) && !(isnan(timestep)));
-  assert(dt_max > 0.0 && !(isinf(dt_max)) && !(isnan(dt_max)));
-  assert(level_step == level_max + integration_step - 1);
-  assert(level_max_sph <= level_max);
-  assert(level_max_nbody <= level_max);
-  assert(n <= nresync);
   for (i=0; i<sph->Nhydro; i++) {
     SphParticle<ndim>& part = sph->GetSphParticlePointer(i);
     if (part.flags.is_dead()) continue;
@@ -1458,6 +1474,12 @@ void SphSimulation<ndim>::ComputeBlockTimesteps(void)
     assert(nbody->nbodydata[i]->level >= level_max_sph);
     assert(nbody->nbodydata[i]->tlast <= t);
   }
+  assert(timestep >= 0.0 && !(isinf(timestep)) && !(isnan(timestep)));
+  assert(dt_max > 0.0 && !(isinf(dt_max)) && !(isnan(dt_max)));
+  assert(level_step == level_max + integration_step - 1);
+  assert(level_max_sph <= level_max);
+  assert(level_max_nbody <= level_max);
+  assert(n <= nresync);
   if (timestep <= 0.0) {
     cout << "Timestep fallen to zero : " << timestep << "    dtmax: " << dt_max
          << "    nresync " << nresync << endl;

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -650,6 +650,9 @@ void SphSimulation<ndim>::MainLoop(void)
   sphint->AdvanceParticles(n, sph->Nhydro, (FLOAT) t, (FLOAT) timestep, sph->GetSphParticleArray());
   nbody->AdvanceParticles(n, nbody->Nnbody, t, timestep, nbody->nbodydata);
 
+  // Add any new particles into the simulation here (e.g. Supernova, wind feedback, etc..)
+  if (sph->newParticles) rebuild_tree = true;
+
   // Check all boundary conditions
   // (DAVID : Move this function to sphint and create an analagous one
   //  for N-body.  Also, only check this on tree-build steps)
@@ -683,8 +686,8 @@ void SphSimulation<ndim>::MainLoop(void)
     sphneib->SearchBoundaryGhostParticles(tghost, simbox, sph);
     sphneib->BuildGhostTree(rebuild_tree, Nsteps, ntreebuildstep, ntreestockstep, timestep, sph);
 
-  // Re-build and communicate the new pruned trees (since the trees will necessarily change
-  // once there has been communication of particles to new domains)
+    // Re-build and communicate the new pruned trees (since the trees will necessarily change
+    // once there has been communication of particles to new domains)
 #ifdef MPI_PARALLEL
     sphneib->BuildPrunedTree(rank, simbox, mpicontrol->mpinode, sph);
     mpicontrol->UpdateAllBoundingBoxes(sph->Nhydro + sph->NPeriodicGhost, sph, sph->kernp);
@@ -713,38 +716,37 @@ void SphSimulation<ndim>::MainLoop(void)
     // Update cells containing active particles
     if (activecount > 0) sphneib->UpdateActiveParticleCounters(sph);
 
-      // Zero accelerations (here for now)
+    // Zero accelerations (here for now)
+    for (i=0; i<sph->Nhydro; i++) {
+      SphParticle<ndim>& part = sph->GetSphParticlePointer(i);
+      if (part.flags.check_flag(active)) {
+        part.levelneib = 0;
+        part.dalphadt  = (FLOAT) 0.0;
+        part.div_v     = (FLOAT) 0.0;
+        part.dudt      = (FLOAT) 0.0;
+        part.gpot      = (FLOAT) 0.0;
+        for (k=0; k<ndim; k++) part.a[k] = (FLOAT) 0.0;
+      }
+    }
+
+    // Calculate all SPH properties
+    sphneib->UpdateAllSphProperties(sph->Nhydro, sph->Ntot, partdata, sph, nbody);
+
+
+    // Update the radiation field
+    if (Nsteps%nradstep == 0 || recomputeRadiation) {
+      radiation->UpdateRadiationField(sph->Nhydro, nbody->Nnbody, sinks->Nsink,
+                                      partdata, nbody->nbodydata, sinks->sink);
       for (i=0; i<sph->Nhydro; i++) {
         SphParticle<ndim>& part = sph->GetSphParticlePointer(i);
-        if (part.flags.check_flag(active)) {
-          part.levelneib = 0;
-          part.dalphadt  = (FLOAT) 0.0;
-          part.div_v     = (FLOAT) 0.0;
-          part.dudt      = (FLOAT) 0.0;
-          part.gpot      = (FLOAT) 0.0;
-          for (k=0; k<ndim; k++) part.a[k] = (FLOAT) 0.0;
-        }
+        sph->ComputeThermalProperties(part);
       }
+    }
 
-      // Calculate all SPH properties
-      sphneib->UpdateAllSphProperties(sph, nbody);
 
-      // Update the radiation field
-      if (Nsteps%nradstep == 0 || recomputeRadiation) {
-        radiation->UpdateRadiationField(sph->Nhydro, nbody->Nnbody, sinks->Nsink,
-                                        sph->GetSphParticleArray(), nbody->nbodydata, sinks->sink);
-        for (i=0; i<sph->Nhydro; i++) {
-          SphParticle<ndim>& part = sph->GetSphParticlePointer(i);
-          sph->ComputeThermalProperties(part);
-        }
-      }
-
-      // Copy properties from original particles to ghost particles
-      LocalGhosts->CopyHydroDataToGhosts(simbox, sph);
-
-      // Calculate gravitational forces from other distant MPI nodes.
-      // Also determines particles that must be exported to other nodes
-      // if too close to the domain boundaries
+    // Calculate gravitational forces from other distant MPI nodes.
+    // Also determines particles that must be exported to other nodes
+    // if too close to the domain boundaries
 #ifdef MPI_PARALLEL
       if (sph->self_gravity == 1) {
         sphneib->UpdateGravityExportList(rank, sph, nbody, simbox);
@@ -769,38 +771,40 @@ void SphSimulation<ndim>::MainLoop(void)
         sphneib->UpdateAllSphHydroForces( sph, nbody, simbox);
       }
 
-      // Add external potential for all active SPH particles
-      for (i=0; i<sph->Nhydro; i++) {
-        SphParticle<ndim>& part = sph->GetSphParticlePointer(i);
-        if (part.flags.check_flag(active)) {
-          sph->extpot->AddExternalPotential(part.r, part.v, part.a, adot, part.gpot);
-        }
+    // Add external potential for all active SPH particles
+    for (i=0; i<sph->Nhydro; i++) {
+      SphParticle<ndim>& part = sph->GetSphParticlePointer(i);
+      if (part.flags.check_flag(active)) {
+        sph->extpot->AddExternalPotential(part.r, part.v, part.a, adot, part.gpot);
       }
+    }
 
-      // Checking if acceleration or other values are invalid
-      for (i=0; i<sph->Nhydro; i++) {
-        SphParticle<ndim>& part = sph->GetSphParticlePointer(i);
-        if (part.flags.check_flag(active)) {
-          for (k=0; k<ndim; k++) assert(part.r[k] == part.r[k]);
-          for (k=0; k<ndim; k++) assert(part.v[k] == part.v[k]);
-          for (k=0; k<ndim; k++) assert(part.a[k] == part.a[k]);
-          assert(part.gpot == part.gpot);
-        }
+
+    // Checking if acceleration or other values are invalid
+    for (i=0; i<sph->Nhydro; i++) {
+      SphParticle<ndim>& part = sph->GetSphParticlePointer(i);
+      if (part.flags.check_flag(active)) {
+        for (k=0; k<ndim; k++) assert(part.r[k] == part.r[k]);
+        for (k=0; k<ndim; k++) assert(part.v[k] == part.v[k]);
+        for (k=0; k<ndim; k++) assert(part.a[k] == part.a[k]);
+        assert(part.gpot == part.gpot);
       }
+    }
 
 #if defined MPI_PARALLEL
-      mpicontrol->GetExportedParticlesAccelerations(sph);
+    mpicontrol->GetExportedParticlesAccelerations(sph);
 #endif
 
-      // Compute the dust forces if present.
-      if (sphdust != NULL){
-        // Copy properties from original particles to ghost particles
-        LocalGhosts->CopyHydroDataToGhosts(simbox, sph);
+    // Compute the dust forces if present.
+    if (sphdust != NULL){
+      // Copy properties from original particles to ghost particles
+      LocalGhosts->CopyHydroDataToGhosts(simbox, sph);
 #ifdef MPI_PARALLEL
-        MpiGhosts->CopyHydroDataToGhosts(simbox, sph);
+      MpiGhosts->CopyHydroDataToGhosts(simbox, sph);
 #endif
         sphdust->UpdateAllDragForces(sph->Nhydro, sph->Ntot, sph->GetSphParticleArray()) ;
       }
+
 
 
     // Zero all active flags once accelerations have been computed
@@ -887,8 +891,10 @@ void SphSimulation<ndim>::MainLoop(void)
   //-----------------------------------------------------------------------------------------------
 
 
-  rebuild_tree = false;
-  recomputeRadiation = false;
+  // Reset flags in preparation for next timestep
+  hydro->newParticles = false;
+  rebuild_tree        = false;
+  recomputeRadiation  = false;
 
 
   // End-step terms for all SPH particles

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -753,13 +753,13 @@ void SphSimulation<ndim>::MainLoop(void)
     }
 
     // Calculate all SPH properties
-    sphneib->UpdateAllSphProperties(sph->Nhydro, sph->Ntot, partdata, sph, nbody);
+    sphneib->UpdateAllSphProperties(sph, nbody);
 
 
     // Update the radiation field
     if (Nsteps%nradstep == 0 || recomputeRadiation) {
       radiation->UpdateRadiationField(sph->Nhydro, nbody->Nnbody, sinks->Nsink,
-                                      partdata, nbody->nbodydata, sinks->sink);
+                                      sph->GetSphParticleArray(), nbody->nbodydata, sinks->sink);
       for (i=0; i<sph->Nhydro; i++) {
         SphParticle<ndim>& part = sph->GetSphParticlePointer(i);
         sph->ComputeThermalProperties(part);

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -233,13 +233,13 @@ void SphSimulation<ndim>::ProcessParameters(void)
   // Supernova feedback
   //-----------------------------------------------------------------------------------------------
   if (stringparams["supernova_feedback"] == "none") {
-    snDriver = new NullSupernovaDriver<ndim>();
+    snDriver = new NullSupernovaDriver<ndim>(this);
   }
   else if (stringparams["supernova_feedback"] == "single") {
-    snDriver = new SedovTestDriver<ndim>(simparams, simunits);
+    snDriver = new SedovTestDriver<ndim>(this,simparams, simunits);
   }
   else if (stringparams["supernova_feedback"] == "random") {
-    snDriver = new RandomSedovTestDriver<ndim>(simparams, simunits, simbox);
+    snDriver = new RandomSedovTestDriver<ndim>(this,simparams, simunits, simbox);
   }
   else {
     string message = "Unrecognised parameter : external_potential = "
@@ -673,7 +673,6 @@ void SphSimulation<ndim>::MainLoop(void)
   //-----------------------------------------------------------------------------------------------
   if (n%(int) pow(2,level_step - level_max) == 0) {
     snDriver->Update(n, level_step, level_max, t, hydro, sphneib, randnumb);
-    if (sph->newParticles) rebuild_tree = true;
   }
 
   // Check all boundary conditions
@@ -916,7 +915,6 @@ void SphSimulation<ndim>::MainLoop(void)
 
 
   // Reset flags in preparation for next timestep
-  hydro->newParticles = false;
   rebuild_tree        = false;
   recomputeRadiation  = false;
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,7 +36,8 @@ PYFOLDER = ../analysis/swig_generated
 #GTEST = /Users#/david/astro/code/gtest-1.6.0/include
 
 
-VPATH = $(PWD)/src:$(PWD)/src/Common:$(PWD)/src/GodunovSph:$(PWD)/src/GradhSph:$(PWD)/src/Headers
+VPATH = $(PWD)/src:$(PWD)/src/Common:$(PWD)/src/Feedback:$(PWD)/src/GodunovSph
+VPATH +=$(PWD)/src/GradhSph:$(PWD)/src/Headers
 VPATH +=$(PWD)/src/Hydrodynamics:$(PWD)/src/MeshlessFV:$(PWD)/src/Mpi:$(PWD)/src/Nbody
 VPATH +=$(PWD)/src/Radiation:$(PWD)/src/SM2013:$(PWD)/src/Thermal:$(PWD)/src/Tree
 VPATH +=$(PWD)/src/UnitTesting
@@ -190,7 +191,7 @@ OBJ += SphIntegration.o SphLeapfrogKDK.o SphLeapfrogDKD.o
 OBJ += RiemannSolver.o
 OBJ += SphNeighbourSearch.o
 OBJ += HydroTree.o Tree.o KDTree.o OctTree.o BruteForceTree.o
-OBJ += MeshlessFVTree.o 
+OBJ += MeshlessFVTree.o
 OBJ += GradhSphTree.o
 OBJ += SM2012SphTree.o
 OBJ += Ewald.o
@@ -213,6 +214,7 @@ OBJ += CodeTiming.o
 OBJ += IC.o
 OBJ += Dust.o
 OBJ += Particle.o
+OBJ += Supernova.o
 
 
 ifeq ($(MPI),1)

--- a/src/Makefile
+++ b/src/Makefile
@@ -214,7 +214,7 @@ OBJ += CodeTiming.o
 OBJ += IC.o
 OBJ += Dust.o
 OBJ += Particle.o
-OBJ += Supernova.o
+OBJ += Supernova.o SupernovaDriver.o
 
 
 ifeq ($(MPI),1)

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,7 +36,7 @@ PYFOLDER = ../analysis/swig_generated
 #GTEST = /Users#/david/astro/code/gtest-1.6.0/include
 
 
-VPATH = $(PWD)/src:$(PWD)/src/Common:$(PWD)/src/Feedback:$(PWD)/src/GodunovSph
+VPATH = $(PWD)/src:$(PWD)/src/Common:$(PWD)/src/Feedback
 VPATH +=$(PWD)/src/GradhSph:$(PWD)/src/Headers
 VPATH +=$(PWD)/src/Hydrodynamics:$(PWD)/src/MeshlessFV:$(PWD)/src/Mpi:$(PWD)/src/Nbody
 VPATH +=$(PWD)/src/Radiation:$(PWD)/src/SM2013:$(PWD)/src/Thermal:$(PWD)/src/Tree

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -707,12 +707,13 @@ void MeshlessFVSimulation<ndim>::PostInitialConditionsSetup(void)
   }
 
   if (nbody->nbody_softening == 1) {
-    nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata);
+    nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata, simbox, ewald);
   }
   else {
     nbody->CalculateDirectGravForces(nbody->Nnbody, nbody->nbodydata);
   }
   nbody->CalculateAllStartupQuantities(nbody->Nnbody, nbody->nbodydata);
+
 
   for (i=0; i<nbody->Nnbody; i++) {
     if (nbody->nbodydata[i]->active) {

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -363,6 +363,23 @@ void MeshlessFVSimulation<ndim>::ProcessParameters(void)
     ExceptionHandler::getIstance().raise(message);
   }
 
+  // Supernova feedback
+  //-----------------------------------------------------------------------------------------------
+  if (stringparams["supernova_feedback"] == "none") {
+    snDriver = new NullSupernovaDriver<ndim>(this);
+  }
+  else if (stringparams["supernova_feedback"] == "single") {
+    snDriver = new SedovTestDriver<ndim>(this,simparams, simunits);
+  }
+  else if (stringparams["supernova_feedback"] == "random") {
+    snDriver = new RandomSedovTestDriver<ndim>(this,simparams, simunits, simbox);
+  }
+  else {
+    string message = "Unrecognised parameter : external_potential = "
+      + simparams->stringparams["supernova_feedback"];
+    ExceptionHandler::getIstance().raise(message);
+  }
+
 
   // Set other important simulation variables
   dt_litesnap         = floatparams["dt_litesnap"]/simunits.t.outscale;

--- a/src/MeshlessFV/MfvMusclSimulation.cpp
+++ b/src/MeshlessFV/MfvMusclSimulation.cpp
@@ -223,7 +223,7 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
 
     // Calculate forces, force derivatives etc.., for active stars/systems
     if (nbody->nbody_softening == 1) {
-      nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata);
+      nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata, simbox, ewald);
     }
     else {
       nbody->CalculateDirectGravForces(nbody->Nnbody, nbody->nbodydata);

--- a/src/MeshlessFV/MfvMusclSimulation.cpp
+++ b/src/MeshlessFV/MfvMusclSimulation.cpp
@@ -102,6 +102,15 @@ void MfvMusclSimulation<ndim>::MainLoop(void)
   // Advance N-body particle positions
   nbody->AdvanceParticles(n, nbody->Nnbody, t, timestep, nbody->nbodydata);
 
+  // Reset rebuild tree flag in preparation for next timestep
+  rebuild_tree        = false;
+
+  // Add any new particles into the simulation here (e.g. Supernova, wind feedback, etc..).
+  //-----------------------------------------------------------------------------------------------
+  if (n%(int) pow(2,level_step - level_max) == 0) {
+    snDriver->Update(n, level_step, level_max, t, hydro, mfvneib, randnumb);
+  }
+
 #ifdef MPI_PARALLEL
   if (Nsteps%ntreebuildstep == 0 || rebuild_tree) {
     mfvneib->BuildPrunedTree(rank, simbox, mpicontrol->mpinode, mfv);

--- a/src/MeshlessFV/MfvRungeKuttaSimulation.cpp
+++ b/src/MeshlessFV/MfvRungeKuttaSimulation.cpp
@@ -158,7 +158,7 @@ void MfvRungeKuttaSimulation<ndim>::MainLoop(void)
 
     // Calculate forces, force derivatives etc.., for active stars/systems
     if (nbody->nbody_softening == 1) {
-      nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata);
+      nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata, simbox, ewald);
     }
     else {
       nbody->CalculateDirectGravForces(nbody->Nnbody, nbody->nbodydata);

--- a/src/Nbody/NbodyHermite4.cpp
+++ b/src/Nbody/NbodyHermite4.cpp
@@ -76,7 +76,9 @@ NbodyHermite4<ndim, kernelclass>::~NbodyHermite4()
 template <int ndim, template<int> class kernelclass>
 void NbodyHermite4<ndim, kernelclass>::CalculateDirectSmoothedGravForces
  (int N,                               ///< [in] Number of stars
-  NbodyParticle<ndim> **star)          ///< [inout] Array of stars/systems
+  NbodyParticle<ndim> **star,          ///< [inout] Array of stars/systems
+  DomainBox<ndim> &simbox,             ///< [in] Simulation domain box
+  Ewald<ndim> *ewald)                  ///< [in] Ewald gravity object pointer
 {
   int i,j,k;                           // Star and dimension counters
   FLOAT dr[ndim];                     // Relative position vector

--- a/src/Nbody/NbodyHermite6TS.cpp
+++ b/src/Nbody/NbodyHermite6TS.cpp
@@ -169,8 +169,10 @@ void NbodyHermite6TS<ndim,kernelclass>::CalculateDirectGravForces
 //=================================================================================================
 template <int ndim, template<int> class kernelclass>
 void NbodyHermite6TS<ndim, kernelclass>::CalculateDirectSmoothedGravForces
-(int N,                             ///< [in] Number of stars
- NbodyParticle<ndim> **star)        ///< [inout] Array of stars/systems
+ (int N,                               ///< [in] Number of stars
+  NbodyParticle<ndim> **star,          ///< [inout] Array of stars/systems
+  DomainBox<ndim> &simbox,             ///< [in] Simulation domain box
+  Ewald<ndim> *ewald)                  ///< [in] Ewald gravity object pointer
 {
   int i,j,k;                        // Star and dimension counters
   FLOAT dr[ndim];                  // Relative position vector

--- a/src/Nbody/NbodyLeapfrogDKD.cpp
+++ b/src/Nbody/NbodyLeapfrogDKD.cpp
@@ -77,7 +77,9 @@ NbodyLeapfrogDKD<ndim, kernelclass>::~NbodyLeapfrogDKD()
 template <int ndim, template<int> class kernelclass>
 void NbodyLeapfrogDKD<ndim, kernelclass>::CalculateDirectSmoothedGravForces
  (int N,                               ///< [in] Number of stars
-  NbodyParticle<ndim> **star)          ///< [inout] Array of stars/systems
+  NbodyParticle<ndim> **star,          ///< [inout] Array of stars/systems
+  DomainBox<ndim> &simbox,             ///< [in] Simulation domain box
+  Ewald<ndim> *ewald)                  ///< [in] Ewald gravity object pointer
 {
   int i,j,k;                           // Star and dimension counters
   FLOAT dr[ndim];                      // Relative position vector

--- a/src/Nbody/NbodyLeapfrogKDK.cpp
+++ b/src/Nbody/NbodyLeapfrogKDK.cpp
@@ -102,66 +102,39 @@ void NbodyLeapfrogKDK<ndim, kernelclass>::CalculateDirectSmoothedGravForces
   for (i=0; i<N; i++) {
     if (star[i]->active == 0) continue;
 
-    if (simbox.PeriodicGravity){
 
-      // Sum grav. contributions for all other stars (excluding star itself)
-      //-------------------------------------------------------------------------------------------
-      for (j=0; j<N; j++) {
-        if (i == j) continue;
+    // Sum grav. contributions for all other stars (excluding star itself)
+    //---------------------------------------------------------------------------------------------
+    for (j=0; j<N; j++) {
+      if (i == j) continue;
 
-        for (k=0; k<ndim; k++) dr[k] = star[j]->r[k] - star[i]->r[k];
-        NearestPeriodicVector(simbox, dr, dr_corr);
+      for (k=0; k<ndim; k++) dr[k] = star[j]->r[k] - star[i]->r[k];
+      NearestPeriodicVector(simbox, dr, dr_corr);
 
-        for (k=0; k<ndim; k++) dv[k] = star[j]->v[k] - star[i]->v[k];
-        drsqd    = DotProduct(dr,dr,ndim);
-        drmag    = sqrt(drsqd) + small_number;
-        invdrmag = (FLOAT) 1.0/drmag;
-        invhmean = (FLOAT) 2.0/(star[i]->h + star[j]->h);
-        drdt     = DotProduct(dv,dr,ndim)*invdrmag;
-        paux     = star[j]->m*invhmean*invhmean*kern.wgrav(drmag*invhmean)*invdrmag;
-        wmean    = kern.w0(drmag*invhmean)*powf(invhmean,ndim);
+      for (k=0; k<ndim; k++) dv[k] = star[j]->v[k] - star[i]->v[k];
+      drsqd    = DotProduct(dr,dr,ndim);
+      drmag    = sqrt(drsqd) + small_number;
+      invdrmag = (FLOAT) 1.0/drmag;
+      invhmean = (FLOAT) 2.0/(star[i]->h + star[j]->h);
+      drdt     = DotProduct(dv,dr,ndim)*invdrmag;
+      paux     = star[j]->m*invhmean*invhmean*kern.wgrav(drmag*invhmean)*invdrmag;
+      wmean    = kern.w0(drmag*invhmean)*powf(invhmean,ndim);
 
-        // Add contribution to main star array
-        star[i]->gpot += star[j]->m*invhmean*kern.wpot(drmag*invhmean);
-        for (k=0; k<ndim; k++) star[i]->a[k] += paux*dr[k];
-        for (k=0; k<ndim; k++) star[i]->adot[k] += paux*dv[k] -
-          (FLOAT) 3.0*paux*drdt*invdrmag*dr[k] + 2.0*twopi*star[j]->m*drdt*wmean*invdrmag*dr[k];
+      // Add contribution to main star array
+      star[i]->gpot += star[j]->m*invhmean*kern.wpot(drmag*invhmean);
+      for (k=0; k<ndim; k++) star[i]->a[k] += paux*dr[k];
+      for (k=0; k<ndim; k++) star[i]->adot[k] += paux*dv[k] -
+        (FLOAT) 3.0*paux*drdt*invdrmag*dr[k] + 2.0*twopi*star[j]->m*drdt*wmean*invdrmag*dr[k];
 
+      // Add periodic gravity contribution (if activated)
+      if (simbox.PeriodicGravity) {
         ewald->CalculatePeriodicCorrection(star[j]->m, dr, aperiodic, potperiodic);
         for (k=0; k<ndim; k++) star[i]->a[k] += aperiodic[k];
         star[i]->gpot += potperiodic;
-
       }
-      //-------------------------------------------------------------------------------------------
 
     }
-    else {
-
-      // Sum grav. contributions for all other stars (excluding star itself)
-      //-------------------------------------------------------------------------------------------
-      for (j=0; j<N; j++) {
-        if (i == j) continue;
-
-        for (k=0; k<ndim; k++) dr[k] = star[j]->r[k] - star[i]->r[k];
-        for (k=0; k<ndim; k++) dv[k] = star[j]->v[k] - star[i]->v[k];
-        drsqd    = DotProduct(dr,dr,ndim);
-        drmag    = sqrt(drsqd) + small_number;
-        invdrmag = (FLOAT) 1.0/drmag;
-        invhmean = (FLOAT) 2.0/(star[i]->h + star[j]->h);
-        drdt     = DotProduct(dv,dr,ndim)*invdrmag;
-        paux     = star[j]->m*invhmean*invhmean*kern.wgrav(drmag*invhmean)*invdrmag;
-        wmean    = kern.w0(drmag*invhmean)*powf(invhmean,ndim);
-
-        // Add contribution to main star array
-        star[i]->gpot += star[j]->m*invhmean*kern.wpot(drmag*invhmean);
-        for (k=0; k<ndim; k++) star[i]->a[k] += paux*dr[k];
-        for (k=0; k<ndim; k++) star[i]->adot[k] += paux*dv[k] -
-          (FLOAT) 3.0*paux*drdt*invdrmag*dr[k] + 2.0*twopi*star[j]->m*drdt*wmean*invdrmag*dr[k];
-
-      }
-      //-------------------------------------------------------------------------------------------
-
-    }
+    //---------------------------------------------------------------------------------------------
 
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/Nbody/NbodySimulation.cpp
+++ b/src/Nbody/NbodySimulation.cpp
@@ -90,6 +90,33 @@ void NbodySimulation<ndim>::ProcessParameters(void)
   simunits.SetupUnits(simparams);
 
 
+  // Boundary condition variables
+  //-----------------------------------------------------------------------------------------------
+  simbox.boundary_lhs[0] = setBoundaryType(stringparams["boundary_lhs[0]"]);
+  simbox.boundary_rhs[0] = setBoundaryType(stringparams["boundary_rhs[0]"]);
+  simbox.boxmin[0] = floatparams["boxmin[0]"]/simunits.r.outscale;
+  simbox.boxmax[0] = floatparams["boxmax[0]"]/simunits.r.outscale;
+
+  if (ndim > 1) {
+    simbox.boundary_lhs[1] = setBoundaryType(stringparams["boundary_lhs[1]"]);
+    simbox.boundary_rhs[1] = setBoundaryType(stringparams["boundary_rhs[1]"]);
+    simbox.boxmin[1] = floatparams["boxmin[1]"]/simunits.r.outscale;
+    simbox.boxmax[1] = floatparams["boxmax[1]"]/simunits.r.outscale;
+  }
+
+  if (ndim == 3) {
+    simbox.boundary_lhs[2] = setBoundaryType(stringparams["boundary_lhs[2]"]);
+    simbox.boundary_rhs[2] = setBoundaryType(stringparams["boundary_rhs[2]"]);
+    simbox.boxmin[2] = floatparams["boxmin[2]"]/simunits.r.outscale;
+    simbox.boxmax[2] = floatparams["boxmax[2]"]/simunits.r.outscale;
+  }
+
+  for (int k=0; k<ndim; k++) {
+    simbox.boxsize[k] = simbox.boxmax[k] - simbox.boxmin[k];
+    simbox.boxhalf[k] = 0.5*simbox.boxsize[k];
+  }
+
+
   // Set-up dummy SPH object in order to have valid pointers in N-body object
   hydro = new NullHydrodynamics<ndim>
     (intparams["hydro_forces"], intparams["self_gravity"], floatparams["h_fac"],
@@ -117,6 +144,25 @@ void NbodySimulation<ndim>::ProcessParameters(void)
     ExceptionHandler::getIstance().raise(message);
   }
   nbody->extpot = extpot;
+
+
+  // Create Ewald periodic gravity object
+  periodicBoundaries = IsAnyBoundaryPeriodic(simbox);
+  if (periodicBoundaries && intparams["self_gravity"] == 1) {
+    ewaldGravity = true;
+    ewald = new Ewald<ndim>
+      (simbox, intparams["gr_bhewaldseriesn"], intparams["in"], intparams["nEwaldGrid"],
+       floatparams["ewald_mult"], floatparams["ixmin"], floatparams["ixmax"],
+       floatparams["EFratio"], timing);
+    simbox.PeriodicGravity = true ;
+  }
+  else{
+    simbox.PeriodicGravity = false ;
+    if (IsAnyBoundaryReflecting(simbox) && intparams["self_gravity"]){
+      ExceptionHandler::getIstance().raise("Error: Reflecting boundaries and self-gravity is not "
+                                       "supported") ;
+    }
+  }
 
 
   // Set important variables for N-body objects
@@ -251,7 +297,13 @@ void NbodySimulation<ndim>::PostInitialConditionsSetup(void)
     }
 
     nbody->Nnbody = nbody->Nstar;
-    nbody->CalculateDirectGravForces(nbody->Nnbody,nbody->nbodydata);
+    if (nbody->nbody_softening == 1) {
+      nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata, simbox, ewald);
+    }
+    else {
+      nbody->CalculateDirectGravForces(nbody->Nnbody, nbody->nbodydata);
+    }
+    //nbody->CalculateDirectGravForces(nbody->Nnbody,nbody->nbodydata);
     nbody->CalculateAllStartupQuantities(nbody->Nnbody,nbody->nbodydata);
     for (i=0; i<nbody->Nnbody; i++) {
       if (nbody->nbodydata[i]->active) {
@@ -312,7 +364,13 @@ void NbodySimulation<ndim>::MainLoop(void)
       nbody->Nnbody = nbody->Nstar;
 
       // Calculate forces for all star by direct-sum
-      nbody->CalculateDirectGravForces(nbody->Nnbody,nbody->nbodydata);
+      if (nbody->nbody_softening == 1) {
+        nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata, simbox, ewald);
+      }
+      else {
+        nbody->CalculateDirectGravForces(nbody->Nnbody, nbody->nbodydata);
+      }
+      //nbody->CalculateDirectGravForces(nbody->Nnbody,nbody->nbodydata);
       nbody->CalculateAllStartupQuantities(nbody->Nnbody,nbody->nbodydata);
 
       // Now create nearest neighbour tree and build any sub-systems from tree
@@ -363,7 +421,13 @@ void NbodySimulation<ndim>::MainLoop(void)
       }
 
       // Calculate forces, force derivatives etc.., for active stars/systems
-      nbody->CalculateDirectGravForces(nbody->Nnbody,nbody->nbodydata);
+      if (nbody->nbody_softening == 1) {
+        nbody->CalculateDirectSmoothedGravForces(nbody->Nnbody, nbody->nbodydata, simbox, ewald);
+      }
+      else {
+        nbody->CalculateDirectGravForces(nbody->Nnbody, nbody->nbodydata);
+      }
+      //nbody->CalculateDirectGravForces(nbody->Nnbody,nbody->nbodydata);
 
       for (i=0; i<nbody->Nnbody; i++) {
         if (nbody->nbodydata[i]->active) {

--- a/src/Nbody/NbodySimulation.cpp
+++ b/src/Nbody/NbodySimulation.cpp
@@ -94,26 +94,26 @@ void NbodySimulation<ndim>::ProcessParameters(void)
   //-----------------------------------------------------------------------------------------------
   simbox.boundary_lhs[0] = setBoundaryType(stringparams["boundary_lhs[0]"]);
   simbox.boundary_rhs[0] = setBoundaryType(stringparams["boundary_rhs[0]"]);
-  simbox.boxmin[0] = floatparams["boxmin[0]"]/simunits.r.outscale;
-  simbox.boxmax[0] = floatparams["boxmax[0]"]/simunits.r.outscale;
+  simbox.min[0] = floatparams["boxmin[0]"]/simunits.r.outscale;
+  simbox.max[0] = floatparams["boxmax[0]"]/simunits.r.outscale;
 
   if (ndim > 1) {
     simbox.boundary_lhs[1] = setBoundaryType(stringparams["boundary_lhs[1]"]);
     simbox.boundary_rhs[1] = setBoundaryType(stringparams["boundary_rhs[1]"]);
-    simbox.boxmin[1] = floatparams["boxmin[1]"]/simunits.r.outscale;
-    simbox.boxmax[1] = floatparams["boxmax[1]"]/simunits.r.outscale;
+    simbox.min[1] = floatparams["boxmin[1]"]/simunits.r.outscale;
+    simbox.max[1] = floatparams["boxmax[1]"]/simunits.r.outscale;
   }
 
   if (ndim == 3) {
     simbox.boundary_lhs[2] = setBoundaryType(stringparams["boundary_lhs[2]"]);
     simbox.boundary_rhs[2] = setBoundaryType(stringparams["boundary_rhs[2]"]);
-    simbox.boxmin[2] = floatparams["boxmin[2]"]/simunits.r.outscale;
-    simbox.boxmax[2] = floatparams["boxmax[2]"]/simunits.r.outscale;
+    simbox.min[2] = floatparams["boxmin[2]"]/simunits.r.outscale;
+    simbox.max[2] = floatparams["boxmax[2]"]/simunits.r.outscale;
   }
 
   for (int k=0; k<ndim; k++) {
-    simbox.boxsize[k] = simbox.boxmax[k] - simbox.boxmin[k];
-    simbox.boxhalf[k] = 0.5*simbox.boxsize[k];
+    simbox.size[k] = simbox.max[k] - simbox.min[k];
+    simbox.half[k] = 0.5*simbox.size[k];
   }
 
 

--- a/tests/feedback_tests/supernova.dat
+++ b/tests/feedback_tests/supernova.dat
@@ -1,0 +1,103 @@
+#--------------------------------------------------------------
+# Sedov Blast Wave test
+# Creates Sedov blast wave test
+#--------------------------------------------------------------
+
+
+#-----------------------------
+# Initial conditions variables
+#-----------------------------
+Simulation run id string                    : run_id = SUPERNOVA1
+Select SPH simulation                       : sim = gradhsph
+Select shocktube initial conditions         : ic = sedov
+Dimensionality of cube                      : ndim = 2
+Pressure of fluid 1                         : press1 = 1.0
+Density of fluid 1                          : rhofluid1 = 1.0
+No. of x-particles in fluid 1               : Nlattice1[0] = 128
+No. of y-particles in fluid 1               : Nlattice1[1] = 128
+No. of y-particles in fluid 1               : Nlattice1[2] = 128
+Local arrangement of particles              : particle_distribution = hexagonal_lattice
+Smooth explosion                            : smooth_ic = 0
+Use dimensionless units                     : dimensionless = 1
+
+
+#------------------------------
+# Simulation boundary variables
+#------------------------------
+LHS position of boundary in x-dimension     : boxmin[0] = -0.5
+RHS position of boundary in x-dimension     : boxmax[0] = 0.5
+LHS position of boundary in y-dimension     : boxmin[1] = -0.433
+RHS position of boundary in y-dimension     : boxmax[1] = 0.433
+LHS position of boundary in z-dimension     : boxmin[2] = -0.4082
+RHS position of boundary in z-dimension     : boxmax[2] = 0.4082
+LHS boundary type in x-dimension            : boundary_lhs[0] = periodic
+RHS boundary type in x-dimension            : boundary_rhs[0] = periodic
+LHS boundary type in y-dimension            : boundary_lhs[1] = periodic
+RHS boundary type in y-dimension            : boundary_rhs[1] = periodic
+LHS boundary type in z-dimension            : boundary_lhs[2] = periodic
+RHS boundary type in z-dimension            : boundary_rhs[2] = periodic
+
+
+#--------------------------
+# Simulation time variables
+#--------------------------
+Simulation end time                         : tend = 10.0
+Time for first snapshot                     : tsnapfirst = 0.0
+Regular snapshot output frequency           : dt_snap = 0.05
+Screen output frequency (in no. of steps)   : noutputstep = 1
+Diagnostic step frequency                   : ndiagstep = 1
+
+
+#------------------------
+# Thermal physics options
+#------------------------
+Switch-on hydrodynamical forces             : hydro_forces = 1
+Main gas thermal physics treatment          : gas_eos = energy_eqn
+Ratio of specific heats of gas              : gamma_eos = 1.6666666666666666
+
+
+#----------------------------------------
+# Smoothed Particle Hydrodynamics options
+#----------------------------------------
+SPH smoothing kernel choice                 : kernel = m4
+SPH smoothing length iteration tolerance    : h_converge = 0.01
+Smoothing length parameter                  : h_fac = 1.2
+
+
+#---------------------------------
+# SPH artificial viscosity options
+#---------------------------------
+Artificial viscosity choice                 : avisc = mon97
+Artificial conductivity choice              : acond = none
+Artificial viscosity alpha value            : alpha_visc = 1.0
+Artificial viscosity beta value             : beta_visc = 2.0
+Riemann solver                              : riemann_solver = exact
+Order of Riemann solver                     : riemann_order = 2
+Slope limiter                               : slope_limiter = gizmo
+Finite mass scheme?                         : zero_mass_flux = 0
+
+
+#-------------------------
+# Time integration options
+#-------------------------
+SPH particle integration option             : sph_integration = lfkdk
+SPH Courant timestep condition multiplier   : courant_mult = 0.1
+SPH acceleration condition multiplier       : accel_mult = 0.2
+SPH energy equation timestep multiplier     : energy_mult = 0.2
+No. of block timestep levels                : Nlevels = 3
+Maximum timestep level difference           : level_diff_max = 1
+
+
+#---------------------
+# Optimisation options
+#---------------------
+Tabulate SPH kernel                         : tabulated_kernel = 0
+SPH neighbour search algorithm              : neib_search = kdtree
+No. of particles per leaf cell              : Nleafmax = 6
+
+
+#--------------
+# Misc. options
+#--------------
+Switch-off self-gravity of gas              : self_gravity = 0
+Add simple supernova driver                 : supernova_feedback = random


### PR DESCRIPTION
See #73 . Doing it in a new branch to cleanup the history. Besides improving comments in a couple of places, I've added the supernova driver call also in the meshless main loop for consistency.
I also got rid of the newParticles flag. The reason is that we already have a rebuild_tree flag, and it was not clear that new flag was introducing anything new. This new way is safer because we can use the existing checks for rebuild_tree.

I believe this is now ready to be merged.