### PR TITLE
Meshless Courant number

### DIFF
--- a/src/MeshlessFV/MeshlessFV.cpp
+++ b/src/MeshlessFV/MeshlessFV.cpp
@@ -222,7 +222,7 @@ void MeshlessFV<ndim>::ComputeThermalProperties
 template <int ndim>
 FLOAT MeshlessFV<ndim>::Timestep(MeshlessFVParticle<ndim> &part)
 {
-  const FLOAT dt_cfl = courant_mult*part.h/part.vsig_max;
+  const FLOAT dt_cfl = 2*courant_mult*part.h/part.vsig_max;
   const FLOAT dt_grav = accel_mult*
     sqrtf(part.h/sqrt(DotProduct(part.a0, part.a0, ndim) + small_number));
 


### PR DESCRIPTION
I've had a look into why the meshless is taking so many steps compared to SPH. The courant criteria differ between the two schemes. In Sph we use:
   h_i / (cs_i + Div v_i)
while in the meshless we were using
 h_i / max_j(v_sig{i,j}),
where 
v_sig{i,j} = cs_i + cs_j - max(dv, 0).


You can see straight away why for tests like the soundwave the meshless is going to to take twice as many steps. I've changed the courant condition in the meshless to 
2 * h_i / max_j(v_sig{i,j}),
which is how it is defined in the GIZMO paper. Now both SPH and the meshless should take closer to the same number of time-steps.


An important question is: which criterion is more correct? I'm not really sure, but it's worth noting that even with the above criterion our timestep criterion is more stringent than GIZMO since they use a definition of h that is twice as big. From the GIZMO paper and Monaghan (1997) I'd expect new expression to be stable up to courant numbers ~ 0.4-0.5. This is still much greater than the 0.15-0.25 that we typically use in the tests.

I'd like your thoughts on this, but it seems to me that both SPH and the meshless *should* be producing similar estimates of the timestep for the soundwave problem, so I'd suggest we either accept this change. Otherwise could modify the courant condition used in SPH to be based upon the signal speed and increase the courant numbers in the tests up to ~0.6.
