### PR TITLE
NeighbourList, Dust

### DIFF
--- a/src/GradhSph/GradhSph.cpp
+++ b/src/GradhSph/GradhSph.cpp
@@ -398,14 +398,9 @@ void GradhSph<ndim, kernelclass>::ComputeThermalProperties
 //=================================================================================================
 template <int ndim, template<int> class kernelclass>
 void GradhSph<ndim, kernelclass>::ComputeSphHydroForces
- (const int i,                         ///< [in] id of particle
-  const int Nneib,                     ///< [in] No. of neins in neibpart array
-  const int *neiblist,                 ///< [in] id of gather neibs in neibpart
-  GradhSphParticle<ndim> &parti,             ///< [inout] Particle i data
-  typename GradhSphParticle<ndim>::HydroForcesParticle* neibpart)     ///< [inout] Neighbour particle data
+ (GradhSphParticle<ndim> &parti,                                   ///< [inout] Particle i data
+  NeighbourList<typename GradhSphBase<ndim>::HydroNeib>& neibpart) ///< [in] List of neighbours
 {
-  int j;                               // Neighbour list id
-  int jj;                              // Aux. neighbour counter
   int k;                               // Dimension counter
   FLOAT alpha_mean;                    // Mean articial viscosity alpha value
   FLOAT draux[ndim];                   // Relative position vector
@@ -424,8 +419,8 @@ void GradhSph<ndim, kernelclass>::ComputeSphHydroForces
 
   // Loop over all potential neighbours in the list
   //-----------------------------------------------------------------------------------------------
-  for (jj=0; jj<Nneib; jj++) {
-    j = neiblist[jj];
+  int Nneib = neibpart.size() ;
+  for (int j=0; j<Nneib; j++) {
     assert(!neibpart[j].flags.is_dead());
 
     const FLOAT invh_j   = 1/neibpart[j].h;
@@ -514,14 +509,9 @@ void GradhSph<ndim, kernelclass>::ComputeSphHydroForces
 //=================================================================================================
 template <int ndim, template<int> class kernelclass>
 void GradhSph<ndim, kernelclass>::ComputeSphHydroGravForces
- (const int i,                         ///< [in] id of particle
-  const int Nneib,                     ///< [in] No. of neins in neibpart array
-  int *neiblist,                       ///< [in] id of gather neibs in neibpart
-  GradhSphParticle<ndim> &parti,             ///< [inout] Particle i data
-  typename GradhSphParticle<ndim>::HydroForcesParticle *neibpart)     ///< [inout] Neighbour particle data
+(GradhSphParticle<ndim> &parti,                                   ///< [inout] Particle i data
+ NeighbourList<typename GradhSphBase<ndim>::HydroNeib>& neibpart) ///< [in] List of neighbours
 {
-  int j;                               // Neighbour list id
-  int jj;                              // Aux. neighbour counter
   int k;                               // Dimension counter
   FLOAT alpha_mean;                    // Mean articial viscosity alpha value
   FLOAT dr[ndim];                      // Relative position vector
@@ -541,9 +531,8 @@ void GradhSph<ndim, kernelclass>::ComputeSphHydroGravForces
 
   // Loop over all potential neighbours in the list
   //-----------------------------------------------------------------------------------------------
-  for (jj=0; jj<Nneib; jj++) {
-    j = neiblist[jj];
-
+  int Nneib = neibpart.size() ;
+  for (int j=0; j<Nneib; j++) {
     assert(!neibpart[j].flags.is_dead());
     assert(neibpart[j].h > (FLOAT) 0.0);
     assert(neibpart[j].rho > (FLOAT) 0.0);
@@ -642,14 +631,9 @@ void GradhSph<ndim, kernelclass>::ComputeSphHydroGravForces
 //=================================================================================================
 template <int ndim, template<int> class kernelclass>
 void GradhSph<ndim, kernelclass>::ComputeSphGravForces
- (const int i,                         ///< [in] id of particle
-  const int Nneib,                     ///< [in] No. of neins in neibpart array
-  int *neiblist,                       ///< [in] id of gather neibs in neibpart
-  GradhSphParticle<ndim> &parti,             ///< [inout] Particle i data
-  typename GradhSphParticle<ndim>::HydroForcesParticle* neibpart)     ///< [inout] Neighbour particle data
+(GradhSphParticle<ndim> &parti,                                   ///< [inout] Particle i data
+ NeighbourList<typename GradhSphBase<ndim>::HydroNeib>& neibpart) ///< [in] List of neighbours
 {
-  int j;                               // Neighbour list id
-  int jj;                              // Aux. neighbour counter
   int k;                               // Dimension counter
   FLOAT dr[ndim];                      // Relative position vector
   FLOAT drmag;                         // Distance
@@ -663,8 +647,8 @@ void GradhSph<ndim, kernelclass>::ComputeSphGravForces
 
   // Loop over all potential neighbours in the list
   //-----------------------------------------------------------------------------------------------
-  for (jj=0; jj<Nneib; jj++) {
-    j = neiblist[jj];
+  int Nneib = neibpart.size();
+  for (int j=0; j<Nneib; j++) {
     assert(!neibpart[j].flags.is_dead());
 
     for (k=0; k<ndim; k++) dr[k] = neibpart[j].r[k] - parti.r[k];
@@ -706,14 +690,9 @@ void GradhSph<ndim, kernelclass>::ComputeSphGravForces
 //=================================================================================================
 template <int ndim>
 void GradhSphBase<ndim>::ComputeDirectGravForces
- (const int i,                         ///< id of particle
-  const int Ndirect,                   ///< No. of nearby 'gather' neighbours
-  int *directlist,                     ///< id of gather neighbour in neibpart
-  GradhSphParticle<ndim> &parti,             ///< Particle i data
-  typename GradhSphParticle<ndim>::HydroForcesParticle* sphdata)          ///< Neighbour particle data
+ (GradhSphParticle<ndim>& parti,                                      ///< Particle i data
+  NeighbourList<typename GradhSphBase<ndim>::DirectNeib>& gravdata)  ///< Neighbour particle data
 {
-  int j;                               // Neighbour particle id
-  int jj;                              // Aux. neighbour loop counter
   int k;                               // Dimension counter
   FLOAT dr[ndim];                      // Relative position vector
   FLOAT drsqd;                         // Distance squared
@@ -723,21 +702,21 @@ void GradhSphBase<ndim>::ComputeDirectGravForces
 
   // Loop over all neighbouring particles in list
   //-----------------------------------------------------------------------------------------------
-  for (jj=0; jj<Ndirect; jj++) {
-    j = directlist[jj];
-    assert(!sphdata[j].flags.is_dead());
+  int Ndirect = gravdata.size();
+  for (int j=0; j<Ndirect; j++) {
+    assert(!gravdata[j].flags.is_dead());
 
-    for (k=0; k<ndim; k++) dr[k] = sphdata[j].r[k] - parti.r[k];
+    for (k=0; k<ndim; k++) dr[k] = gravdata[j].r[k] - parti.r[k];
     drsqd    = DotProduct(dr,dr,ndim) + small_number;
     invdrmag = (FLOAT) 1.0/sqrt(drsqd);
     invdr3   = invdrmag*invdrmag*invdrmag;
 
     // Add contribution to current particle
-    for (k=0; k<ndim; k++) parti.atree[k] += sphdata[j].m*dr[k]*invdr3;
-    parti.gpot += sphdata[j].m*invdrmag;
+    for (k=0; k<ndim; k++) parti.atree[k] += gravdata[j].m*dr[k]*invdr3;
+    parti.gpot += gravdata[j].m*invdrmag;
 
     // Sanity-checkt to ensure particles are really un-softened direct-sum neighbours
-    assert(drsqd >= parti.hrangesqd && drsqd >= sphdata[j].hrangesqd);
+    assert(drsqd >= parti.hrangesqd && drsqd >= gravdata[j].hrangesqd);
 
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/Headers/NeighbourManager.h
+++ b/src/Headers/NeighbourManager.h
@@ -41,7 +41,7 @@ public:
   typedef typename iterator_type::reference reference ;
   typedef typename iterator_type::pointer   pointer ;
 
-  NeighbourIterator(int p_idx, ParticleType* p_part) :
+  NeighbourIterator(int* p_idx, ParticleType* p_part) :
     _p_idx(p_idx), _p_part(p_part) { };
 
   // Dereference
@@ -111,7 +111,7 @@ public:
   }
 
 private:
-  int * _p_idx;
+  int* _p_idx;
   ParticleType* _p_part;
 };
 

--- a/src/Headers/NeighbourManager.h
+++ b/src/Headers/NeighbourManager.h
@@ -80,12 +80,6 @@ public:
     _p_idx -= n;
     return *this;
   }
-  NeighbourIterator<ParticleType> operator+(std::size_t n) {
-    return NeighbourIterator<ParticleType>(_p_idx+n, _p_part);
-  }
-  NeighbourIterator<ParticleType> operator-(std::size_t n) {
-    return NeighbourIterator<ParticleType>(_p_idx-n, _p_part);
-  }
 
   // Comparison
   bool operator==(const NeighbourIterator<ParticleType>& other) const {
@@ -110,10 +104,37 @@ public:
     return (*this < other);
   }
 
+
 private:
   int* _p_idx;
   ParticleType* _p_part;
 };
+
+// Arithmetic operators should be free functions:
+template<class ParticleType>
+NeighbourIterator<ParticleType> operator+(NeighbourIterator<ParticleType>& p,
+                                          std::size_t n) {
+  return NeighbourIterator<ParticleType>(p) += n ;
+}
+template<class ParticleType>
+NeighbourIterator<ParticleType> operator+(std::size_t n,
+                                          NeighbourIterator<ParticleType>& p) {
+  return NeighbourIterator<ParticleType>(p) += n ;
+}
+template<class ParticleType>
+NeighbourIterator<ParticleType> operator-(NeighbourIterator<ParticleType>& p,
+                                          std::size_t n) {
+  return NeighbourIterator<ParticleType>(p) -= n ;
+}
+template<class ParticleType>
+NeighbourIterator<ParticleType> operator-(std::size_t n,
+                                          NeighbourIterator<ParticleType>& p) {
+  return NeighbourIterator<ParticleType>(p) -= n ;
+}
+
+
+
+
 
 //=================================================================================================
 //  Class NeighbourList

--- a/src/Headers/NeighbourManager.h
+++ b/src/Headers/NeighbourManager.h
@@ -9,6 +9,7 @@
 #define NEIGHBOURMANAGER_H_
 
 
+#include <iterator>
 #include <vector>
 using namespace std;
 #include "TreeCell.h"
@@ -20,6 +21,134 @@ struct ListLength {
   int Nhydro;
   int Ndirect;
   int Ngrav;
+};
+
+
+
+//=================================================================================================
+//  Class NeighbourIterator
+/// \brief   Template class for iterating of neighbour lists.
+/// \details Random Access Iterator. Iterates over members of a neighbour list.
+/// \author  R. A. Booth
+/// \date    20/12/2016
+//=================================================================================================
+template <class ParticleType>
+class NeighbourIterator :
+    public std::iterator<std::random_access_iterator_tag, ParticleType>
+{
+  typedef std::iterator<std::random_access_iterator_tag, ParticleType> iterator_type ;
+public:
+  typedef typename iterator_type::reference reference ;
+  typedef typename iterator_type::pointer   pointer ;
+
+  NeighbourIterator(int p_idx, ParticleType* p_part) :
+    _p_idx(p_idx), _p_part(p_part) { };
+
+  // Dereference
+  reference operator*() const {
+    return _p_part[*_p_idx];
+  }
+  reference operator[](std::size_t n) const {
+    return _p_part[_p_idx[n]];
+  }
+  pointer operator->() const {
+    return &(_p_part[*_p_idx]);
+  }
+
+  // Increment / Decrement
+  NeighbourIterator<ParticleType>& operator++(int) {
+    ++_p_idx;
+    return *this;
+  }
+  NeighbourIterator<ParticleType>& operator--(int) {
+    --_p_idx;
+    return *this;
+  }
+  NeighbourIterator<ParticleType> operator++() {
+    return NeighbourIterator<ParticleType>(_p_idx++, _p_part);
+  }
+  NeighbourIterator<ParticleType> operator--() {
+    return NeighbourIterator<ParticleType>(_p_idx--, _p_part);
+  }
+
+  // Add / subtract
+  NeighbourIterator<ParticleType>& operator+=(std::size_t n) {
+    _p_idx += n;
+    return *this;
+  }
+  NeighbourIterator<ParticleType>& operator-=(std::size_t n) {
+    _p_idx -= n;
+    return *this;
+  }
+  NeighbourIterator<ParticleType> operator+(std::size_t n) {
+    return NeighbourIterator<ParticleType>(_p_idx+n, _p_part);
+  }
+  NeighbourIterator<ParticleType> operator-(std::size_t n) {
+    return NeighbourIterator<ParticleType>(_p_idx-n, _p_part);
+  }
+
+  // Comparison
+  bool operator==(const NeighbourIterator<ParticleType>& other) const {
+    assert(_p_part == other._p_part);
+    return _p_idx == other._p_idx;
+  }
+  bool operator!=(const NeighbourIterator<ParticleType>& other) const {
+    return !(*this == other);
+  }
+  bool operator<(const NeighbourIterator<ParticleType>& other) const {
+    assert(_p_part == other._p_part);
+    return _p_idx < other._p_idx;
+  }
+  bool operator>(const NeighbourIterator<ParticleType>& other) const {
+    assert(_p_part == other._p_part);
+    return _p_idx < other._p_idx;
+  }
+  bool operator<=(const NeighbourIterator<ParticleType>& other) const {
+    return !(*this > other);
+  }
+  bool operator>=(const NeighbourIterator<ParticleType>& other) const {
+    return (*this < other);
+  }
+
+private:
+  int * _p_idx;
+  ParticleType* _p_part;
+};
+
+//=================================================================================================
+//  Class NeighbourList
+/// \brief   Template container class which holds a list of neighbour lists.
+/// \details Allows the neighbour lists to be fully abstracted.
+/// \author  R. A. Booth
+/// \date    20/12/2016
+//=================================================================================================
+template<class ParticleType>
+class NeighbourList {
+public:
+  NeighbourList(std::vector<int>& idx,
+      std::vector<ParticleType>& neib) :
+        _idx(idx), _neibpart(neib) { };
+
+  NeighbourIterator<ParticleType> begin() {
+    return NeighbourIterator<ParticleType>(&_idx.front(), &_neibpart.front());
+  }
+  NeighbourIterator<ParticleType> end() {
+    return NeighbourIterator<ParticleType>(&_idx.back(), &_neibpart.front());
+  }
+
+  std::size_t size() const {
+    return _idx.size();
+  }
+  const ParticleType& operator[](std::size_t i) const {
+    return _neibpart[_idx[i]];
+  }
+  ParticleType& operator[](std::size_t i) {
+    return _neibpart[_idx[i]];
+  }
+
+private:
+  std::vector<int>& _idx;
+  std::vector<ParticleType>& _neibpart;
 };
 
 //=================================================================================================
@@ -37,7 +166,7 @@ private:
   int _NCellDirectNeib;
   vector<int> neiblist;
   vector<int> directlist;
-  vector<int> neib_idx ;
+  vector<int> neib_idx;
   vector<ParticleType > neibdata;
 
   vector<int> culled_neiblist;
@@ -47,11 +176,11 @@ private:
   vector<FLOAT> drmag;
 
   const DomainBox<ndim>* _domain;
-  const ParticleTypeRegister* _types ;
-  double _kernrange ;
+  const ParticleTypeRegister* _types;
+  double _kernrange;
 
-  typedef struct {}        _true_type ;
-  typedef struct {char c;} _false_type ;
+  typedef struct {}        _true_type;
+  typedef struct {char c;} _false_type;
 
 public:
   using NeighbourManagerDim<ndim>::tempneib;
@@ -64,7 +193,7 @@ public:
     _domain(&domain),
     _types(&(hydro->types)),
     _kernrange(hydro->kernp->kernrange)
-  { } ;
+  { };
 
   NeighbourManager(const ParticleTypeRegister& types, double kernrange,
       const DomainBox<ndim>& domain)
@@ -72,10 +201,10 @@ public:
     _domain(&domain),
     _types(&types),
     _kernrange(kernrange)
-  { } ;
+  { };
 
   void clear() {
-    NeighbourManagerDim<ndim>::clear() ;
+    NeighbourManagerDim<ndim>::clear();
     neiblist.clear();
     neibdata.clear();
     neib_idx.clear();
@@ -89,7 +218,7 @@ public:
   //===============================================================================================
   template<class InParticleType>
   void EndSearch(const TreeCellBase<ndim> &cell, const InParticleType* partdata) {
-    _EndSearch(cell, partdata, false) ;
+    _EndSearch(cell, partdata, false);
   }
   //===============================================================================================
   // EndSearchGravity
@@ -98,7 +227,7 @@ public:
   //===============================================================================================
   template<class InParticleType>
   void EndSearchGravity(const TreeCellBase<ndim> &cell, const InParticleType* partdata) {
-    _EndSearch(cell, partdata, true) ;
+    _EndSearch(cell, partdata, true);
   }
 
   //===============================================================================================
@@ -139,15 +268,29 @@ public:
    const bool do_pair_once)                            ///< [in]
   {
     if (do_pair_once)
-      TrimNeighbourLists<InParticleType,_true_type>(p, hydromask, false) ;
+      TrimNeighbourLists<InParticleType,_true_type>(p, hydromask, false);
     else
-      TrimNeighbourLists<InParticleType,_false_type>(p, hydromask, false) ;
+      TrimNeighbourLists<InParticleType,_false_type>(p, hydromask, false);
 
 
     *neiblist_p=&culled_neiblist[0];
     *neibdata_p=&neibdata[0];
     return culled_neiblist.size();
 
+  }
+
+  template<class InParticleType>
+  NeighbourList<ParticleType> GetParticleNeib
+  (const InParticleType& p,                            ///< [in] Particle to collect the neibs for
+   const Typemask& hydromask,                          ///< [in] Boolean flags listing types we need
+   const bool do_pair_once)                            ///< [in]
+  {
+    if (do_pair_once)
+      TrimNeighbourLists<InParticleType,_true_type>(p, hydromask, false);
+    else
+      TrimNeighbourLists<InParticleType,_false_type>(p, hydromask, false);
+
+    return NeighbourList<ParticleType>(culled_neiblist, neibdata) ;
   }
 
   //===============================================================================================
@@ -171,14 +314,14 @@ public:
    int** smoothgravlist_p,                             ///< [out] List of smoothed gravity neibs
    ParticleType** neibdata_p) {                        ///< [out] List of particle data.
 
-    TrimNeighbourLists<InParticleType,_false_type>(p, hydromask, true) ;
+    TrimNeighbourLists<InParticleType,_false_type>(p, hydromask, true);
 
     ListLength listlength;
     listlength.Nhydro=culled_neiblist.size();
     listlength.Ndirect=directlist.size();
     listlength.Ngrav=smoothgravlist.size();
 
-    assert((listlength.Nhydro + listlength.Ndirect + listlength.Ngrav) == GetNumAllNeib()) ;
+    assert((listlength.Nhydro + listlength.Ndirect + listlength.Ngrav) == GetNumAllNeib());
 
     *neiblist_p = &culled_neiblist[0];
     *directlist_p = &directlist[0];
@@ -198,114 +341,114 @@ private:
   ///          otherwise they are discarded. Periodic corrections are included.
   //===============================================================================================
   template<class InParticleType>
-   void _EndSearch(const TreeCellBase<ndim> &cell, const InParticleType* partdata, bool keep_direct=true) {
+  void _EndSearch(const TreeCellBase<ndim> &cell, const InParticleType* partdata, bool keep_direct=true) {
 
-     assert(partdata != NULL);
-
-
-     FLOAT dr[ndim];                      // Relative position vector
-     FLOAT drsqd;                         // Distance squared
-     FLOAT rc[ndim];                      // Position of cell
-     const FLOAT hrangemaxsqd = pow(cell.rmax + _kernrange*cell.hmax,2);
-     const FLOAT rmax = cell.rmax;
-     for (int k=0; k<ndim; k++) rc[k] = cell.rcell[k];
+    assert(partdata != NULL);
 
 
-     const GhostNeighbourFinder<ndim> GhostFinder(*_domain, cell) ;
-     int MaxGhosts = GhostFinder.MaxNumGhosts() ;
-
-     Typemask gravmask = _types->gravmask ;
-
-     assert(!keep_direct || MaxGhosts==1 ||
-         (gravcell.size() == 0 && tempdirectneib.size() == 0)) ;
-
-     assert(neibdata.size()==0);
-     assert(directlist.size()==0);
+    FLOAT dr[ndim];                      // Relative position vector
+    FLOAT drsqd;                         // Distance squared
+    FLOAT rc[ndim];                      // Position of cell
+    const FLOAT hrangemaxsqd = pow(cell.rmax + _kernrange*cell.hmax,2);
+    const FLOAT rmax = cell.rmax;
+    for (int k=0; k<ndim; k++) rc[k] = cell.rcell[k];
 
 
-     // Now load the particles
+    const GhostNeighbourFinder<ndim> GhostFinder(*_domain, cell);
+    int MaxGhosts = GhostFinder.MaxNumGhosts();
 
-     // Start from direct neighbours
-     if (keep_direct) {
-       for (int ii=0; ii< tempdirectneib.size(); ii++) {
-         const int i = tempdirectneib[ii] ;
-         const InParticleType& part = partdata[i];
-         // Forget immediately: direct particles and particles that do not interact gravitationally
-         if (part.flags.is_dead()) continue;
-         if (!gravmask[part.ptype]) continue;
+    Typemask gravmask = _types->gravmask;
 
-         // Now create the particle
-         GhostFinder.ConstructGhostsScatterGather(part, neibdata);
-         directlist.push_back(neibdata.size()-1);
-         neib_idx.push_back(i) ;
-       }
-     }
+    assert(!keep_direct || MaxGhosts==1 ||
+        (gravcell.size() == 0 && tempdirectneib.size() == 0));
 
-     assert(directlist.size() == neibdata.size() &&
-         neib_idx.size()   == neibdata.size()) ;
-
-     // Now look at the hydro candidate neighbours
-     // First the ones that need ghosts to be created on the fly
-     int Nneib = directlist.size();
-     for (int ii=0; ii < tempperneib.size(); ii++) {
-       const int i = tempperneib[ii] ;
-       if (partdata[i].flags.is_dead()) continue;
-
-       GhostFinder.ConstructGhostsScatterGather(partdata[i], neibdata);
-
-       while (Nneib < neibdata.size()) {
-         int Nmax = neibdata.size() ;
-         for (int k=0; k<ndim; k++) dr[k] = neibdata[Nneib].r[k] - rc[k];
-         drsqd = DotProduct(dr, dr, ndim);
-         FLOAT h2 = rmax + _kernrange*neibdata[Nneib].h;
-         if (drsqd < hrangemaxsqd || drsqd < h2*h2) {
-           neiblist.push_back(Nneib);
-           neib_idx.push_back(i) ;
-           Nneib++ ;
-         }
-         else if (keep_direct && gravmask[neibdata[Nneib].ptype]) {
-           directlist.push_back(Nneib);
-           neib_idx.push_back(i) ;
-           Nneib++ ;
-         }
-         else if (Nmax > Nneib) {
-           Nmax-- ;
-           if (Nmax > Nneib)
-             neibdata[Nneib] = neibdata[Nmax];
-           neibdata.resize(neibdata.size()-1);
-         }
-       }// Loop over Ghosts
-     }
-
-     // Store the number of periodic particles in the neiblist
-     _NPeriodicGhosts = neiblist.size() ;
-
-     // Find those particles that do not need ghosts on the fly
-     for (int ii=0; ii<tempneib.size(); ii++) {
-       const int i = tempneib[ii];
-       if (partdata[i].flags.is_dead()) continue;
+    assert(neibdata.size()==0);
+    assert(directlist.size()==0);
 
 
-       for (int k=0; k<ndim; k++) dr[k] = partdata[i].r[k] - rc[k];
-       drsqd = DotProduct(dr,dr,ndim);
-       FLOAT h = rmax + _kernrange*partdata[i].h;
-       if (drsqd < hrangemaxsqd || drsqd < h*h) {
-         neibdata.push_back(partdata[i]);
-         neiblist.push_back(Nneib);
-         neib_idx.push_back(i) ;
-         Nneib++;
-       } else if (keep_direct && gravmask[neibdata[Nneib].ptype]) {
-         // Hydro candidates that fail the test get demoted to direct neighbours
-         neibdata.push_back(partdata[i]);
-         directlist.push_back(Nneib);
-         neib_idx.push_back(i) ;
-         Nneib++;
-       }
-     }
+    // Now load the particles
 
-     _NCellDirectNeib = directlist.size();
-     assert(neibdata.size() == (neiblist.size() + directlist.size()));
-   }
+    // Start from direct neighbours
+    if (keep_direct) {
+      for (int ii=0; ii< tempdirectneib.size(); ii++) {
+        const int i = tempdirectneib[ii];
+        const InParticleType& part = partdata[i];
+        // Forget immediately: direct particles and particles that do not interact gravitationally
+        if (part.flags.is_dead()) continue;
+        if (!gravmask[part.ptype]) continue;
+
+        // Now create the particle
+        GhostFinder.ConstructGhostsScatterGather(part, neibdata);
+        directlist.push_back(neibdata.size()-1);
+        neib_idx.push_back(i);
+      }
+    }
+
+    assert(directlist.size() == neibdata.size() &&
+        neib_idx.size()   == neibdata.size());
+
+    // Now look at the hydro candidate neighbours
+    // First the ones that need ghosts to be created on the fly
+    int Nneib = directlist.size();
+    for (int ii=0; ii < tempperneib.size(); ii++) {
+      const int i = tempperneib[ii];
+      if (partdata[i].flags.is_dead()) continue;
+
+      GhostFinder.ConstructGhostsScatterGather(partdata[i], neibdata);
+
+      while (Nneib < neibdata.size()) {
+        int Nmax = neibdata.size();
+        for (int k=0; k<ndim; k++) dr[k] = neibdata[Nneib].r[k] - rc[k];
+        drsqd = DotProduct(dr, dr, ndim);
+        FLOAT h2 = rmax + _kernrange*neibdata[Nneib].h;
+        if (drsqd < hrangemaxsqd || drsqd < h2*h2) {
+          neiblist.push_back(Nneib);
+          neib_idx.push_back(i);
+          Nneib++;
+        }
+        else if (keep_direct && gravmask[neibdata[Nneib].ptype]) {
+          directlist.push_back(Nneib);
+          neib_idx.push_back(i);
+          Nneib++;
+        }
+        else if (Nmax > Nneib) {
+          Nmax--;
+          if (Nmax > Nneib)
+            neibdata[Nneib] = neibdata[Nmax];
+          neibdata.resize(neibdata.size()-1);
+        }
+      }// Loop over Ghosts
+    }
+
+    // Store the number of periodic particles in the neiblist
+    _NPeriodicGhosts = neiblist.size();
+
+    // Find those particles that do not need ghosts on the fly
+    for (int ii=0; ii<tempneib.size(); ii++) {
+      const int i = tempneib[ii];
+      if (partdata[i].flags.is_dead()) continue;
+
+
+      for (int k=0; k<ndim; k++) dr[k] = partdata[i].r[k] - rc[k];
+      drsqd = DotProduct(dr,dr,ndim);
+      FLOAT h = rmax + _kernrange*partdata[i].h;
+      if (drsqd < hrangemaxsqd || drsqd < h*h) {
+        neibdata.push_back(partdata[i]);
+        neiblist.push_back(Nneib);
+        neib_idx.push_back(i);
+        Nneib++;
+      } else if (keep_direct && gravmask[neibdata[Nneib].ptype]) {
+        // Hydro candidates that fail the test get demoted to direct neighbours
+        neibdata.push_back(partdata[i]);
+        directlist.push_back(Nneib);
+        neib_idx.push_back(i);
+        Nneib++;
+      }
+    }
+
+    _NCellDirectNeib = directlist.size();
+    assert(neibdata.size() == (neiblist.size() + directlist.size()));
+  }
 
 
   //===============================================================================================
@@ -324,7 +467,7 @@ private:
 
     const GhostNeighbourFinder<ndim> GhostFinder(*_domain);
 
-    Typemask gravmask = _types->gravmask ;
+    Typemask gravmask = _types->gravmask;
 
     culled_neiblist.clear();
     smoothgravlist.clear();
@@ -337,7 +480,7 @@ private:
       int ii = neiblist[jj];
 
       // If do_pair_once is true then only get the neighbour for the first of the two times the
-      if (not _first_appearance(p, neibdata[ii], do_pair_once())) continue ;
+      if (not _first_appearance(p, neibdata[ii], do_pair_once())) continue;
 
       // Compute relative position and distance quantities for pair
       for (int k=0; k<ndim; k++) draux[k] = neibdata[ii].r[k] - rp[k];
@@ -346,7 +489,7 @@ private:
 
       const FLOAT drsqd = DotProduct(draux,draux,ndim) + small_number;
 
-      //if (drsqd <= small_number) continue ;
+      //if (drsqd <= small_number) continue;
 
       // Record if neighbour is direct-sum or and SPH neighbour.
       // If SPH neighbour, also record max. timestep level for neighbour
@@ -375,12 +518,12 @@ private:
     return
         (neibpart.flags.is_mirror()) ||
         (p.level > neibpart.level) ||
-        (p.level == neibpart.level &&  p.iorig < neibpart.iorig) ;
+        (p.level == neibpart.level &&  p.iorig < neibpart.iorig);
   }
 
   template<class InParticleType>
   bool _first_appearance(const InParticleType& p, const ParticleType& neibpart, _false_type) {
-    return true ;
+    return true;
   }
 
 

--- a/src/Headers/SlopeLimiter.h
+++ b/src/Headers/SlopeLimiter.h
@@ -50,9 +50,8 @@ class SlopeLimiter
   SlopeLimiter() {};
   virtual ~SlopeLimiter() {};
 
-  template <class Part1Type, class Part2Type>
-  void CellLimiter(Part1Type& parti,
-                           const Part2Type* neibpart, const int* neiblist, int Nneib) {};
+  template <class Part1Type, class NeibList>
+  void CellLimiter(Part1Type& parti, NeibList& neibpart) {} ;
 
   template <class Part1Type, class Part2Type>
   void ComputeLimitedSlopes(Part1Type& parti, Part2Type& partj,
@@ -136,17 +135,16 @@ class TVDScalarLimiter : public SlopeLimiter<ndim>
   {};
 
   //===============================================================================================
-  template <class Part1Type, class Part2Type>
-  void CellLimiter(Part1Type& parti,
-                   const Part2Type* neibpart, const int* neiblist, int Nneib) {
+  template <class Part1Type, class NeibList>
+  void CellLimiter(Part1Type& parti, NeibList& neibpart) {
     double dr[ndim] ;
     double alpha[ndim+2] ;
-    int j, jj, k, var ;
+    int j, k, var ;
 
     for (var=0; var<ndim+2; var++) alpha[var] = 1.0 ;
 
-    for (jj=0; jj<Nneib; jj++) {
-      j = neiblist[jj];
+    int Nneib = neibpart.size() ;
+    for (j=0; j<Nneib; j++) {
 
       for (k=0; k<ndim; k++) dr[k] = neibpart[j].r[k] - parti.r[k];
 
@@ -195,12 +193,11 @@ class ScalarLimiter: public SlopeLimiter<ndim>
   {};
 
   //===============================================================================================
-  template <class Part1Type, class Part2Type>
-  void CellLimiter(Part1Type& parti,
-                   const Part2Type* neibpart, const int* neiblist, int Nneib) {
+  template <class Part1Type, class NeibList>
+  void CellLimiter(Part1Type& parti, NeibList& neibpart) {
     double dr[ndim], drmax ;
     double Wmax[ndim+2], Wmin[ndim+2] ;
-    int j, jj, k, var ;
+    int j, k, var ;
 
     // Get the max / min values over the neighbours
     for (var=0; var<ndim+2; var++) {
@@ -210,8 +207,8 @@ class ScalarLimiter: public SlopeLimiter<ndim>
     // Compute the maximum particle volume and max/min values in
     // that volume.
     drmax = 0 ;
-    for (jj=0; jj<Nneib; jj++) {
-      j = neiblist[jj];
+    int Nneib = neibpart.size() ;
+    for (j=0; j<Nneib; j++) {
 
       for (k=0; k<ndim; k++) dr[k] = neibpart[j].r[k] - parti.r[k];
 
@@ -266,13 +263,12 @@ class Springel2009Limiter: public SlopeLimiter<ndim>
   {};
 
   //===============================================================================================
-  template <class Part1Type, class Part2Type>
-  void CellLimiter(Part1Type& parti,
-                   const Part2Type* neibpart, const int* neiblist, int Nneib) {
+  template <class Part1Type, class NeibList>
+  void CellLimiter(Part1Type& parti, NeibList& neibpart) {
     double dr[ndim] ;
     double dWmax[ndim+2], dWmin[ndim+2] ;
     double alpha[ndim+2] ;
-    int j, jj, k, var ;
+    int j, k, var ;
 
     // Get the max / min values over the neighbours
     for (var=0; var<ndim+2; var++) {
@@ -282,8 +278,8 @@ class Springel2009Limiter: public SlopeLimiter<ndim>
 
     // Compute the maximum particle volume and max/min values in
     // that volume.
-    for (jj=0; jj<Nneib; jj++) {
-      j = neiblist[jj];
+    int Nneib = neibpart.size() ;
+    for (j=0; j<Nneib; j++) {
       for (var=0; var<ndim+2; var++) {
         dWmax[var] = max(dWmax[var], neibpart[j].Wprim[var]) ;
         dWmin[var] = min(dWmin[var], neibpart[j].Wprim[var]) ;
@@ -295,8 +291,7 @@ class Springel2009Limiter: public SlopeLimiter<ndim>
     }
 
 
-    for (jj=0; jj<Nneib; jj++) {
-      j = neiblist[jj];
+    for (j=0; j<Nneib; j++) {
 
       for (k=0; k<ndim; k++) dr[k] = neibpart[j].r[k] - parti.r[k];
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -74,12 +74,12 @@ endif
 
 # Select the compiler
 # -------------------------------------------------------------------------------------------------
-ifeq ($(findstring g++,$(CPP)),g++)
-OPT += $(GCCOPT)
-else ifeq ($(CPP),icpc)
+ifeq ($(CPP),icpc)
 OPT += $(ICCOPT)
-else ifeq ($(CPP),clang)
+else ifeq ($(findstring clang,$(CPP)),clang)
 OPT += $(CLANGOPT)
+else ifeq ($(findstring g++,$(CPP)),g++)
+OPT += $(GCCOPT)
 else ifeq ($(CPP),mpic++)
 MPI = 1
 OPT += $(GCCOPT)

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -412,16 +412,14 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGradientMatrices
         // Make local copy of hmask for active particle
         Typemask hmask = mfv->types[activepart[j].ptype].hmask;
 
-        const bool do_pair_once=false;
         activepart[j].levelneib = 0;
 
-        int* mfvlist;
-        GradientParticle* neibpart;
-
-        const int Nneib=neibmanager.GetParticleNeib(activepart[j],hmask,&mfvlist,&neibpart,do_pair_once);
+        const bool do_pair_once=false;
+        NeighbourList<GradientParticle> neiblist =
+            neibmanager.GetParticleNeib(activepart[j],hmask,do_pair_once);
 
         // Compute all neighbour contributions to gradients
-        mfv->ComputeGradients(i, Nneib, mfvlist, activepart[j], neibpart);
+        mfv->ComputeGradients(activepart[j], neiblist);
 
       }
       //-------------------------------------------------------------------------------------------
@@ -585,15 +583,12 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
         // Make a local copy of the hydro neighbour mask
         Typemask hydromask = mfv->types[activepart[j].ptype].hydromask;
 
-        int* mfvlist;
-        FluxParticle* neibpart;
-
         bool do_pair_once=true;
-
-        const int Nneib = neibmanager.GetParticleNeib(activepart[j],hydromask,&mfvlist,&neibpart,do_pair_once);
+        NeighbourList<FluxParticle> neiblist =
+            neibmanager.GetParticleNeib(activepart[j],hydromask,do_pair_once);
 
         // Compute all neighbour contributions to hydro fluxes
-        mfv->ComputeGodunovFlux(i, Nneib, timestep, mfvlist, activepart[j], neibpart);
+        mfv->ComputeGodunovFlux(activepart[j], neiblist, timestep);
 
       }
       //-------------------------------------------------------------------------------------------
@@ -773,21 +768,17 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllGravForces
           // Only calculate gravity for active particle types that have self-gravity activated
           if (mfv->types[activepart[j].ptype].self_gravity){
 
-		    int* neiblist;
-		    int* directlist;
-		    int* gravlist;
-		    GravParticle* neibpart;
-		    const bool do_grav=true;
-		    const ListLength listlength = neibmanager.GetParticleNeibGravity(activepart[j],hydromask,&neiblist,&directlist,&gravlist,&neibpart);
+		    GravityNeighbourLists<GravParticle> neiblists =
+		        neibmanager.GetParticleNeibGravity(activepart[j],hydromask);
 
 
             // Compute forces with hydro neighbours
-            mfv->ComputeSmoothedGravForces(i, listlength.Nhydro, neiblist, activepart[j], neibpart);
+            mfv->ComputeSmoothedGravForces(activepart[j], neiblists.neiblist);
             // Compute forces with non-hydro neighbours
-            mfv->ComputeSmoothedGravForces(i, listlength.Ngrav, gravlist, activepart[j], neibpart);
+            mfv->ComputeSmoothedGravForces(activepart[j], neiblists.smooth_gravlist);
 
             // Compute direct gravity forces between distant particles
-            mfv->ComputeDirectGravForces(i, listlength.Ndirect, directlist, activepart[j], neibpart);
+            mfv->ComputeDirectGravForces(activepart[j], neiblists.directlist);
 
             // Compute gravitational force due to distant cells
             if (multipole == "monopole") {
@@ -804,10 +795,10 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllGravForces
               int Ntotneib = neibmanager.GetNumAllNeib() ;
               for (int jj=0; jj<Ntotneib; jj++) {
 
-                if (!gravmask[neibpart[jj].ptype]) continue ;
+                if (!gravmask[neibmanager[jj].ptype]) continue ;
 
-                for (int k=0; k<ndim; k++) draux[k] = neibpart[jj].r[k] - activepart[j].r[k];
-                ewald->CalculatePeriodicCorrection(neibpart[jj].m, draux, aperiodic, potperiodic);
+                for (int k=0; k<ndim; k++) draux[k] = neibmanager[jj].r[k] - activepart[j].r[k];
+                ewald->CalculatePeriodicCorrection(neibmanager[jj].m, draux, aperiodic, potperiodic);
                 for (int k=0; k<ndim; k++) activepart[j].atree[k] += aperiodic[k];
                 activepart[j].gpot += potperiodic;
               }

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -418,6 +418,9 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGradientMatrices
         NeighbourList<GradientParticle> neiblist =
             neibmanager.GetParticleNeib(activepart[j],hmask,do_pair_once);
 
+#if defined(VERIFY_ALL)
+        neibmanager.VerifyNeighbourList(i, mfv->Nhydro, mfvdata, "all");
+#endif
         // Compute all neighbour contributions to gradients
         mfv->ComputeGradients(activepart[j], neiblist);
 
@@ -586,6 +589,10 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
         bool do_pair_once=true;
         NeighbourList<FluxParticle> neiblist =
             neibmanager.GetParticleNeib(activepart[j],hydromask,do_pair_once);
+
+#if defined(VERIFY_ALL)
+        neibmanager.VerifyNeighbourList(i, Nhydro, mfvdata, "all");
+#endif
 
         // Compute all neighbour contributions to hydro fluxes
         mfv->ComputeGodunovFlux(activepart[j], neiblist, timestep);

--- a/src/MeshlessFV/MfvCommon.cpp
+++ b/src/MeshlessFV/MfvCommon.cpp
@@ -238,14 +238,9 @@ int MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeH
 //=================================================================================================
 template <int ndim, template<int> class kernelclass, class SlopeLimiter>
 void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeGradients
- (const int i,                                 ///< [in] id of particle
-  const int Nneib,                             ///< [in] No. of neins in neibpart array
-  int *neiblist,                               ///< [in] id of gather neibs in neibpart
-  MeshlessFVParticle<ndim> &part,              ///< [inout] Particle i data
-  typename MeshlessFVParticle<ndim>::GradientParticle* neibpart)          ///< [inout] Neighbour particle data
+(MeshlessFVParticle<ndim>& part,                                ///< [inout] Particle data
+ NeighbourList<typename MeshlessFV<ndim>::GradNeib>& neibpart)  ///< [inout] Neighbour data
 {
-  int j;                                       // Neighbour list id
-  int jj;                                      // Aux. neighbour loop counter
   int k;                                       // Dimension counter
   int var;                                     // Primitive variable counter
   FLOAT draux[ndim], dv[ndim];                 // Relative position / velocity vector
@@ -273,8 +268,8 @@ void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeGradients
 
   // Loop over all potential neighbours in the list
   //-----------------------------------------------------------------------------------------------
-  for (jj=0; jj<Nneib; jj++) {
-    j = neiblist[jj];
+  int Nneib = neibpart.size();
+  for (int j=0; j<Nneib; j++) {
 
     for (k=0; k<ndim; k++) draux[k] = neibpart[j].r[k] - part.r[k];
     for (k=0; k<ndim; k++) dv[k] = neibpart[j].v[k] - part.v[k];
@@ -324,7 +319,7 @@ void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeGradients
 
   // Finally apply the slope limiter
   //-----------------------------------------------------------------------------------------------
-  limiter.CellLimiter(part, neibpart, neiblist, Nneib) ;
+  limiter.CellLimiter(part, neibpart) ;
 
   assert(part.vsig_max >= part.sound);
 
@@ -343,14 +338,9 @@ void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeGradients
 //=================================================================================================
 template <int ndim, template<int> class kernelclass, class SlopeLimiter>
 void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeSmoothedGravForces
- (const int i,                         ///< [in] id of particle
-  const int Nneib,                     ///< [in] No. of neins in neibpart array
-  int *neiblist,                       ///< [in] id of gather neibs in neibpart
-  MeshlessFVParticle<ndim> &parti,     ///< [inout] Particle i data
-  typename MeshlessFVParticle<ndim>::GravParticle* neibpart)  ///< [inout] Neighbour particle data
+(MeshlessFVParticle<ndim>& parti,                               ///< [inout] Particle data
+ NeighbourList<typename MeshlessFV<ndim>::GravNeib>& neibpart)  ///< [inout] Neighbour data
 {
-  int j;                               // Neighbour list id
-  int jj;                              // Aux. neighbour counter
   int k;                               // Dimension counter
   FLOAT dr[ndim];                      // Relative position vector
   FLOAT drmag;                         // Distance
@@ -363,8 +353,8 @@ void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeSmoothedGravForces
 
   // Loop over all potential neighbours in the list
   //-----------------------------------------------------------------------------------------------
-  for (jj=0; jj<Nneib; jj++) {
-    j = neiblist[jj];
+  int Nneib = neibpart.size();
+  for (int j=0; j<Nneib; j++) {
     assert(!neibpart[j].flags.is_dead());
 
     const FLOAT mj = neibpart[j].m;
@@ -402,14 +392,9 @@ void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeSmoothedGravForces
 //=================================================================================================
 template <int ndim, template<int> class kernelclass, class SlopeLimiter>
 void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeDirectGravForces
- (const int i,                         ///< id of particle
-  const int Ndirect,                   ///< No. of nearby 'gather' neighbours
-  int *directlist,                     ///< id of gather neighbour in neibpart
-  MeshlessFVParticle<ndim> &parti,      ///< Particle i data
-  typename MeshlessFVParticle<ndim>::GravParticle* neibdata)  ///< Neighbour particle data
+(MeshlessFVParticle<ndim>& parti,                                 ///< [inout] Particle data
+ NeighbourList<typename MeshlessFV<ndim>::DirectNeib>& neibdata)  ///< [inout] Neighbour data
 {
-  int j;                               // Neighbour particle id
-  int jj;                              // Aux. neighbour loop counter
   int k;                               // Dimension counter
   FLOAT dr[ndim];                      // Relative position vector
   FLOAT drsqd;                         // Distance squared
@@ -418,8 +403,8 @@ void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeDirectGravForces
 
   // Loop over all neighbouring particles in list
   //-----------------------------------------------------------------------------------------------
-  for (jj=0; jj<Ndirect; jj++) {
-    j = directlist[jj];
+  int Nneib = neibdata.size();
+  for (int j=0; j<Nneib; j++) {
     assert(!neibdata[j].flags.is_dead());
 
     for (k=0; k<ndim; k++) dr[k] = neibdata[j].r[k] - parti.r[k];

--- a/src/MeshlessFV/MfvMuscl.cpp
+++ b/src/MeshlessFV/MfvMuscl.cpp
@@ -75,15 +75,10 @@ MfvMuscl<ndim, kernelclass,SlopeLimiter>::~MfvMuscl()
 //=================================================================================================
 template <int ndim, template<int> class kernelclass, class SlopeLimiter>
 void MfvMuscl<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
- (const int i,                         ///< [in] id of particle
-  const int Nneib,                     ///< [in] No. of neins in neibpart array
-  const FLOAT timestep,                ///< [in] Minimum timestep size
-  int *neiblist,                       ///< [in] id of gather neibs in neibpart
-  MeshlessFVParticle<ndim> &part,      ///< [inout] Particle i data
-  typename MeshlessFVParticle<ndim>::FluxParticle* neibpart)  ///< [inout] Neighbour particle data
+(MeshlessFVParticle<ndim>& part,                                ///< [inout] Particle data
+ NeighbourList<typename MeshlessFV<ndim>::FluxNeib>& neibpart,  ///< [inout] Neighbour data
+ FLOAT timestep)                                                ///< [in]    Current timstep size
 {
-  int j;                               // Neighbour list id
-  int jj;                              // Aux. neighbour counter
   int k;                               // Dimension counter
   int var;                             // Particle state vector variable counter
   FLOAT Aij[ndim];                     // Pseudo 'Area' vector
@@ -106,9 +101,8 @@ void MfvMuscl<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
 
   // Loop over all potential neighbours in the list
   //-----------------------------------------------------------------------------------------------
-  for (jj=0; jj<Nneib; jj++) {
-    j = neiblist[jj];
-
+  int Nneib = neibpart.size() ;
+  for (int j=0; j<Nneib; j++) {
     const FLOAT invh_j   = (FLOAT) 1.0/neibpart[j].h;
     const FLOAT volume_j = (FLOAT) 1/neibpart[j].ndens;
 

--- a/src/MeshlessFV/MfvRungeKutta.cpp
+++ b/src/MeshlessFV/MfvRungeKutta.cpp
@@ -63,15 +63,10 @@ MfvRungeKutta<ndim, kernelclass,SlopeLimiter>::MfvRungeKutta
 //=================================================================================================
 template <int ndim, template<int> class kernelclass, class SlopeLimiter>
 void MfvRungeKutta<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
- (const int i,                         ///< [in] id of particle
-  const int Nneib,                     ///< [in] No. of neins in neibpart array
-  const FLOAT timestep,                ///< ..
-  int *neiblist,                       ///< [in] id of gather neibs in neibpart
-  MeshlessFVParticle<ndim> &part,      ///< [inout] Particle i data
-  typename MeshlessFVParticle<ndim>::FluxParticle *neibpart)  ///< [inout] Neighbour particle data
+(MeshlessFVParticle<ndim>& part,                                ///< [inout] Particle data
+ NeighbourList<typename MeshlessFV<ndim>::FluxNeib>& neibpart,  ///< [inout] Neighbour data
+ FLOAT timestep)                                                ///< [in]    Current timstep size
 {
-  int j;                               // Neighbour list id
-  int jj;                              // Aux. neighbour counter
   int k;                               // Dimension counter
   int var;                             // Particle state vector variable counter
   FLOAT Aij[ndim];                     // Pseudo 'Area' vector
@@ -96,8 +91,8 @@ void MfvRungeKutta<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
 
   // Loop over all potential neighbours in the list
   //-----------------------------------------------------------------------------------------------
-  for (jj=0; jj<Nneib; jj++) {
-    j = neiblist[jj];
+  int Nneib = neibpart.size() ;
+  for (int j=0; j<Nneib; j++) {
 
     FLOAT invh_j   = 1/neibpart[j].h;
     FLOAT volume_j = 1/neibpart[j].ndens;


### PR DESCRIPTION
Here are some more changes based upon the neighbour manager concept. Giovanni suggested earlier that we were paying a heavy price in copying the particles unnecessarily in the dust tests, which he implemented as a temporary fix while we were getting the neighbour manager working. I can now indeed confirm that those copies were coming at a high cost. The changes introduced here reduce the running time of the dust tests from 138s to 99s on my laptop with OpenMP and 4 threads. 

What I've done here is to introduce a small NeighbourList template class. This class is a simple container for a single neighbour list, e.g. the direct list. It also hides the iteration over the indices of the neighbour array from the user and allows us to return the list of neighbours as if it were a vector. It's also cheap to copy around a NeighbourList since it only holds a reference to the internal arrays of the NeigbourManager. The implementation is safe since the underlying vectors are hidden so the users can't accidentally kill the list of neighbours or mess up the indexing, but they are free to modify the neighbour particles.

On top of this class I've implemented an iterator, NeighbourIterator, which might come in useful, but is not currently being used.


I think this pull request goes a long way towards implementing our ideal interface for neighbour lists. There are still a few open questions though:
1) How should we deal with the indices of the neighbours original location in memory? It would be simple enough to add a reference to neib_idx to the NeighbourList if we want, so we could provide a uniform index-based way of accessing this information. However, this approach would deviate from a simple standard library container type interface, and it's not obvious how to extend this to use the iterators (or whether we even should).
2) How should we implement the interface for the gravity neighbours, which need three different neighbour lists?  The current implementation can't be default constructed, so we can't just pass three of these objects in and have the function fill them. I can see two plausible ways to get around this:
   1) We could get around this by holding pointers rather than references. I'm reluctant to do this though, because its likely to introduce lots of edge cases that would need guarding against and that seems like a bad idea. 
   2) Splitting up the 'generation' of the neighbour lists for a particular particle from the return of them. To do this, either  the user would have to pre-generate the reduced lists for a particle by calling a function, or we could hide the generation and force the user to pass in the particle and masks each time they want to generate a list. We'd have to either recalculate the lists multiple times, or try to cache the input and only recalculae when it changes.

Thoughts?
