### PR TITLE
Unused/Uninitialised variables

### DIFF
--- a/src/Common/Dust.cpp
+++ b/src/Common/Dust.cpp
@@ -532,7 +532,6 @@ void DustSphNgbFinder<ndim, ParticleType>::FindNeibAndDoForces
     int cc;                                      // Aux. cell counter
     int i;                                       // Particle id
     int j;                                       // Aux. particle counter
-    int jj;                                      // Aux. particle counter
     int k;                                       // Dimension counter
     int Nactive;                                 // ..
     vector<int>                 activelist(_tree->MaxNumPartInLeafCell()); // Ids of Active parts

--- a/src/GradhSph/GradhSphTree.cpp
+++ b/src/GradhSph/GradhSphTree.cpp
@@ -84,8 +84,9 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphProperties
   Nbody<ndim> *nbody)                      ///< [in] Pointer to N-body object
 {
   int cactive;                             // No. of active tree cells
-  vector<TreeCellBase<ndim> > celllist;		   // List of active tree cells
-
+  //int Ntot = sph->Ntot;
+  vector<TreeCellBase<ndim> > celllist;		 // List of active tree cells
+  ParticleType<ndim>* sphdata = reinterpret_cast<ParticleType<ndim>*> (sph->GetSphParticleArray());
 #ifdef MPI_PARALLEL
   double twork = timing->RunningTime();  // Start time (for load balancing)
 #endif
@@ -93,18 +94,12 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphProperties
   debug2("[GradhSphTree::UpdateAllSphProperties]");
   CodeTiming::BlockTimer timer = timing->StartNewTimer("SPH_PROPERTIES");
 
-  int Ntot = sph->Ntot;
-  ParticleType<ndim>* sphdata =
-      reinterpret_cast<ParticleType<ndim>*> (sph->GetSphParticleArray());
-
   // Find list of all cells that contain active particles
   cactive = tree->ComputeActiveCellList(celllist);
   assert(cactive <= tree->gtot);
 
   // If there are no active cells, return to main loop
-  if (cactive == 0) {
-    return;
-  }
+  if (cactive == 0) return;
 
 
   // Set-up all OMP threads
@@ -701,4 +696,3 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
 template class GradhSphTree<1,GradhSphParticle>;
 template class GradhSphTree<2,GradhSphParticle>;
 template class GradhSphTree<3,GradhSphParticle>;
-

--- a/src/GradhSph/GradhSphTree.cpp
+++ b/src/GradhSph/GradhSphTree.cpp
@@ -104,7 +104,7 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphProperties
 
   // Set-up all OMP threads
   //===============================================================================================
-#pragma omp parallel default(none) shared(cactive,celllist,cout,nbody,sph,sphdata,Ntot)
+#pragma omp parallel default(none) shared(cactive,celllist,cout,nbody,sph,sphdata)
   {
 #if defined _OPENMP
     const int ithread = omp_get_thread_num();

--- a/src/Headers/GhostNeighbours.hpp
+++ b/src/Headers/GhostNeighbours.hpp
@@ -417,8 +417,8 @@ private:
 	  const int old_size = ngbs.size()-1;
 	  const ParticleType& real_particle = ngbs.back();
 	  FLOAT h2 = real_particle.hrangesqd ;
-	  FLOAT r[ndim];
-	  for (int k=0; k<ndim; k++) r[k]=real_particle.r[k];
+	  //FLOAT r[ndim];
+	  //for (int k=0; k<ndim; k++) r[k]=real_particle.r[k];
 
 	  // Loop over the possible directions for reflections
 	  for (int k = 0; k < ndim; k++){

--- a/src/Headers/GhostNeighbours.hpp
+++ b/src/Headers/GhostNeighbours.hpp
@@ -199,31 +199,35 @@ public:
 	/// \date   09/10/2016
 	/// \return A boolean saying whether the boxes overlap
 	//=================================================================================================
-	bool PeriodicBoxOverlap(const Box<ndim>& box1, const Box<ndim>& box2) const
-	{
-	  if (!_any_periodic)
-	    return BoxOverlap(ndim, box1.min, box1.max, box2.min, box2.max) ;
-	  else {
-	    // Find the smallest possible distance between box centres
-        FLOAT dr[ndim];
-        FLOAT dr_corr[ndim];
-	    for (int k=0; k<ndim; k++)
-	      dr[k] = 0.5*((box2.max[k] + box2.min[k]) - (box1.max[k] + box1.min[k])) ;
+  bool PeriodicBoxOverlap(const Box<ndim>& box1, const Box<ndim>& box2) const
+  {
+    if (!_any_periodic) {
+      return BoxOverlap(ndim, box1.min, box1.max, box2.min, box2.max) ;
+    }
+    else {
 
-	    // Find whether the boxes can overlap.
-	    if (PeriodicDistanceCorrection(dr, dr_corr).is_periodic()) {
-	      Box<ndim> periodic_box ;
-	      for (int k=0; k<ndim; k++) {
-	        periodic_box.min[k] = box2.min[k] + dr_corr[k];
-	        periodic_box.max[k] = box2.max[k] + dr_corr[k];
-	      }
-	      return BoxOverlap(ndim, box1.min, box1.max, periodic_box.min, periodic_box.max) ;
-	    }
-	    else {
-	      return BoxOverlap(ndim, box1.min, box1.max, box2.min, box2.max) ;
-	    }
-	  }
-	}
+      // Find the smallest possible distance between box centres
+      FLOAT dr[ndim];
+      FLOAT dr_corr[ndim];
+      for (int k=0; k<ndim; k++) {
+        dr[k] = (FLOAT) 0.5*((box2.max[k] + box2.min[k]) - (box1.max[k] + box1.min[k]));
+        dr_corr[k] = (FLOAT) 0.0;
+      }
+
+      // Find whether the boxes can overlap.
+      if (PeriodicDistanceCorrection(dr, dr_corr).is_periodic()) {
+        Box<ndim> periodic_box;
+        for (int k=0; k<ndim; k++) {
+          periodic_box.min[k] = box2.min[k] + dr_corr[k];
+          periodic_box.max[k] = box2.max[k] + dr_corr[k];
+        }
+        return BoxOverlap(ndim, box1.min, box1.max, periodic_box.min, periodic_box.max);
+      }
+      else {
+        return BoxOverlap(ndim, box1.min, box1.max, box2.min, box2.max);
+      }
+    }
+  }
 
 	//=================================================================================================
 	/// \brief  Find the maximum number of mirrors required

--- a/src/Headers/NeighbourManager.h
+++ b/src/Headers/NeighbourManager.h
@@ -227,7 +227,7 @@ private:
 
      // Start from direct neighbours
      if (keep_direct) {
-       for (int ii=0; ii< tempdirectneib.size(); ii++) {
+       for (int ii=0; ii<(int) tempdirectneib.size(); ii++) {
          const int i = tempdirectneib[ii] ;
          const InParticleType& part = partdata[i];
          // Forget immediately: direct particles and particles that do not interact gravitationally
@@ -246,14 +246,14 @@ private:
 
      // Now look at the hydro candidate neighbours
      // First the ones that need ghosts to be created on the fly
-     int Nneib = directlist.size();
-     for (int ii=0; ii < tempperneib.size(); ii++) {
-       const int i = tempperneib[ii] ;
+     int Nneib = (int) directlist.size();
+     for (int ii=0; ii<(int) tempperneib.size(); ii++) {
+       const int i = tempperneib[ii];
        if (partdata[i].flags.is_dead()) continue;
 
        GhostFinder.ConstructGhostsScatterGather(partdata[i], neibdata);
 
-       while (Nneib < neibdata.size()) {
+       while (Nneib < (int) neibdata.size()) {
          int Nmax = neibdata.size() ;
          for (int k=0; k<ndim; k++) dr[k] = neibdata[Nneib].r[k] - rc[k];
          drsqd = DotProduct(dr, dr, ndim);
@@ -270,8 +270,7 @@ private:
          }
          else if (Nmax > Nneib) {
            Nmax-- ;
-           if (Nmax > Nneib)
-             neibdata[Nneib] = neibdata[Nmax];
+           if (Nmax > Nneib) neibdata[Nneib] = neibdata[Nmax];
            neibdata.resize(neibdata.size()-1);
          }
        }// Loop over Ghosts
@@ -281,7 +280,7 @@ private:
      _NPeriodicGhosts = neiblist.size() ;
 
      // Find those particles that do not need ghosts on the fly
-     for (int ii=0; ii<tempneib.size(); ii++) {
+     for (int ii=0; ii<(int) tempneib.size(); ii++) {
        const int i = tempneib[ii];
        if (partdata[i].flags.is_dead()) continue;
 
@@ -333,7 +332,7 @@ private:
 
     // Go through the hydro neighbour candidates and check the distance. The ones that are not real neighbours
     // are demoted to the direct list
-    for (int jj=0; jj < neiblist.size(); jj++) {
+    for (int jj=0; jj<(int) neiblist.size(); jj++) {
       int ii = neiblist[jj];
 
       // If do_pair_once is true then only get the neighbour for the first of the two times the

--- a/src/Hydrodynamics/RiemannSolver.cpp
+++ b/src/Hydrodynamics/RiemannSolver.cpp
@@ -238,12 +238,14 @@ void ExactRiemannSolver<ndim>::ComputeStarRegion
     else if (2.0*fabs(pstar - pold)/(pstar + pold) < tolerance) break;
 
     // Check the star variables have not become NaNs
-    if (pstar != pstar || ustar != ustar) {
-      std::cout << "Checking Riemann values : " << pstar << "   "
-                << ustar << "   iteration : " << iteration << std::endl;
+    //if (pstar != pstar || ustar != ustar) {
+    if (!isfinite(pstar)) {
+      std::cout << "Checking Riemann values : " << pstar
+                << "   iteration : " << iteration << std::endl;
       std::cout << "rho : " << dl << "   " << dr << "     vel : " << ul << "    "
                 << ur << "    press : " << pl << "    " << pr << std::endl;
-      std::cout << "f/fprime : " << fl << "   " << fr << "   " << flprime << "   " << frprime << endl;
+      std::cout << "f/fprime : " << fl << "   " << fr
+                << "   " << flprime << "   " << frprime << endl;
       ExceptionHandler::getIstance().raise("Error : Invalid star values in Riemann solver");
     }
 
@@ -436,14 +438,14 @@ void ExactRiemannSolver<ndim>::ComputeFluxes
   const FLOAT cl = sqrt(gamma*Wleft[ipress]/Wleft[irho]);      // LHS sound speed
   const FLOAT cr = sqrt(gamma*Wright[ipress]/Wright[irho]);    // RHS sound speed
   int k,kv;                            // Dimension counters
-  FLOAT pstar;                         // Pressure in star region
-  FLOAT ustar;                         // Velocity in star region
   FLOAT p,d,u;                         // Primitive variables at s=0 from Riemann solver
   FLOAT rotMat[ndim][ndim];            // Rotation matrix
   FLOAT invRotMat[ndim][ndim];         // Inverse rotation matrix
   FLOAT uleft[ndim];                   // Left velocity state
   FLOAT uright[ndim];                  // Right velocity state
   FLOAT Wface[nvar];                   // Primitive vector at working face
+  FLOAT pstar = small_number;          // Pressure in star region
+  FLOAT ustar = (FLOAT) 0.0;           // Velocity in star region
 
   assert(Wleft[ipress] > 0.0);
   assert(Wleft[irho] > 0.0);

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -751,22 +751,14 @@ template <int ndim>
 void MeshlessFVSimulation<ndim>::ComputeBlockTimesteps(void)
 {
   int istep;                                 // Aux. variable for changing steps
-  int last_level;                            // Previous timestep level
   int level;                                 // Particle timestep level
-  int level_max_aux;                         // Aux. maximum level variable
   int level_max_nbody = 0;                   // level_max for star particles only
   int level_max_old = level_max;             // Old level_max
   int level_max_hydro = 0;                   // level_max for hydro particles only
   int level_min_hydro = 9999999;             // level_min for hydro particles
-  int level_nbody;                           // local thread var. for N-body level
-  int level_hydro;                           // local thread var. for hydro level
   int nfactor;                               // Increase/decrease factor of n
-  //int nstep;                                 // Particle integer step-size
   DOUBLE dt;                                 // Aux. timestep variable
   DOUBLE dt_min = big_number_dp;             // Minimum timestep
-  //DOUBLE dt_min_aux;                         // Aux. minimum timestep variable
-  //DOUBLE dt_nbody;                           // Aux. minimum N-body timestep
-  //DOUBLE dt_hydro;                           // Aux. minimum hydro timestep
 
   debug2("[MeshlessFVSimulation::ComputeBlockTimesteps]");
   CodeTiming::BlockTimer timer = timing->StartNewTimer("BLOCK_TIMESTEPS");
@@ -783,7 +775,7 @@ void MeshlessFVSimulation<ndim>::ComputeBlockTimesteps(void)
     n = 0;
     timestep = big_number_dp;
 
-#pragma omp parallel default(none) shared(dt_min) private(dt, level) //private(dt,dt_min_aux,dt_nbody,dt_hydro,i)
+#pragma omp parallel default(none) shared(dt_min) private(dt, level)
     {
       // Initialise all timestep and min/max variables
       DOUBLE dt_min_aux = big_number_dp;
@@ -911,15 +903,14 @@ void MeshlessFVSimulation<ndim>::ComputeBlockTimesteps(void)
     level_max_hydro = 0;
 
 
-#pragma omp parallel default(shared) private(dt, level) \
-    shared(dt_min, istep, level_max_hydro, level_max_nbody, level_max_old, nfactor)
+#pragma omp parallel default(shared) private (dt, istep, level, nfactor) \
+shared(dt_min, level_max_hydro, level_max_nbody, level_max_old)
     {
       int last_level;
       int nstep;
       int level_max_aux = 0;
       int level_nbody   = 0;
       int level_hydro   = 0;
-      DOUBLE dt;
       DOUBLE dt_hydro   = big_number_dp;
       DOUBLE dt_nbody   = big_number_dp;
 

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -365,10 +365,8 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGradientMatrices
     int cc;                                        // Aux. cell counter
     int i;                                         // Particle id
     int j;                                         // Aux. particle counter
-    int jj;                                        // Aux. particle counter
     int k;                                         // Dimension counter
     int Nactive;                                   // ..
-    int Nneibmax    = Nneibmaxbuf[ithread];        // ..
     int* activelist = activelistbuf[ithread];      // ..
     int* levelneib  = levelneibbuf[ithread];       // ..
     ParticleType<ndim>* activepart = activepartbuf[ithread];   // ..
@@ -527,16 +525,14 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
     const int ithread = 0;
 #endif
     int i;                                         // Particle id
-    int j;                                         // Aux. particle counter
     int k;                                         // Dimension counter
     int Nactive;                                   // ..
-    int Nneibmax      = Nneibmaxbuf[ithread];      // ..
     int* activelist   = activelistbuf[ithread];    // ..
     FLOAT (*dQBuffer)[ndim+2]      = new FLOAT[Ntot][ndim+2];  // ..
     FLOAT (*fluxBuffer)[ndim+2]    = new FLOAT[Ntot][ndim+2];  // ..
     FLOAT (*rdmdtBuffer)[ndim]     = new FLOAT[Ntot][ndim];    // ..
     ParticleType<ndim>* activepart = activepartbuf[ithread];   // ..
-    ParticleType<ndim>* neibpart   = neibpartbuf[ithread];     // ..
+    //ParticleType<ndim>* neibpart   = neibpartbuf[ithread];     // ..
     NeighbourManager<ndim,FluxParticle>& neibmanager = neibmanagerbufflux[ithread];
 
     for (int i=0; i<Ntot; i++) {
@@ -708,14 +704,10 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllGravForces
     int Nactive;                                 // ..
     FLOAT aperiodic[ndim];                       // ..
     FLOAT draux[ndim];                           // Aux. relative position vector
-    FLOAT drsqd;                                 // Distance squared
-    FLOAT hrangesqdi;                            // Kernel gather extent
-    FLOAT macfactor;                             // Gravity MAC factor
     FLOAT potperiodic;                           // ..
-    FLOAT rp[ndim];                              // ..
     int *activelist  = activelistbuf[ithread];   // ..
     ParticleType<ndim>* activepart  = activepartbuf[ithread];   // ..
-    ParticleType<ndim>* neibpart    = neibpartbuf[ithread];     // ..
+    //ParticleType<ndim>* neibpart    = neibpartbuf[ithread];     // ..
     Typemask gravmask = mfv->types.gravmask;
     NeighbourManagerGrav neibmanager = neibmanagerbufgrav[ithread];
     Typemask hydromask ;
@@ -772,7 +764,6 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllGravForces
 		    int* directlist;
 		    int* gravlist;
 		    GravParticle* neibpart;
-		    const bool do_grav=true;
 		    const ListLength listlength = neibmanager.GetParticleNeibGravity(activepart[j],hydromask,&neiblist,&directlist,&gravlist,&neibpart);
 
 

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -88,7 +88,9 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllProperties
   DomainBox<ndim> &simbox)                 ///< [in] Simulation domain box
 {
   int cactive;                             // No. of active tree cells
-  vector<TreeCellBase<ndim> > celllist;            // List of active cells
+  //int Ntot = mfv->Ntot;
+  vector<TreeCellBase<ndim> > celllist;    // List of active cells
+  MeshlessFVParticle<ndim> *mfvdata = mfv->GetMeshlessFVParticleArray();
   //ParticleType<ndim> *partdata = static_cast<ParticleType<ndim>* > (sph_gen);
 #ifdef MPI_PARALLEL
   double twork = timing->RunningTime();  // Start time (for load balancing)
@@ -97,18 +99,11 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllProperties
   debug2("[MeshlessFVTree::UpdateAllProperties]");
   CodeTiming::BlockTimer timer = timing->StartNewTimer("MFV_PROPERTIES");
 
-  int Ntot = mfv->Ntot;
-  MeshlessFVParticle<ndim> *mfvdata = mfv->GetMeshlessFVParticleArray();
-
-
-
   // Find list of all cells that contain active particles
   cactive = tree->ComputeActiveCellList(celllist);
 
   // If there are no active cells, return to main loop
-  if (cactive == 0) {
-    return;
-  }
+  if (cactive == 0) return;
 
 
   // Set-up all OMP threads

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -108,7 +108,7 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllProperties
 
   // Set-up all OMP threads
   //===============================================================================================
-#pragma omp parallel default(none) shared(cactive,celllist,cout,nbody,mfv,mfvdata,Ntot)
+#pragma omp parallel default(none) shared(cactive,celllist,cout,nbody,mfv,mfvdata)
   {
 #if defined _OPENMP
     const int ithread = omp_get_thread_num();
@@ -505,7 +505,7 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
   for (int t = neibmanagerbufflux.size(); t < Nthreads; ++t)
     neibmanagerbufflux.push_back(NeighbourManagerFlux(mfv, simbox));
 
-  int Nhydro = mfv->Nhydro ;
+  //int Nhydro = mfv->Nhydro;
   int Ntot = mfv->Ntot;
   MeshlessFVParticle<ndim> *mfvdata = mfv->GetMeshlessFVParticleArray();
 
@@ -519,7 +519,7 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
 
   // Set-up all OMP threads
   //===============================================================================================
-#pragma omp parallel default(none) shared(cactive,celllist,mfv,mfvdata, Nhydro, Ntot, simbox)
+#pragma omp parallel default(none) shared(cactive,celllist,mfv,mfvdata,Ntot)
   {
 #if defined _OPENMP
     const int ithread = omp_get_thread_num();

--- a/src/Nbody/NbodySimulation.cpp
+++ b/src/Nbody/NbodySimulation.cpp
@@ -505,12 +505,15 @@ void NbodySimulation<ndim>::ComputeBlockTimesteps(void)
 
           // Move up one level (if levels are correctly synchronised) or
           // down several levels if required
-          if (level < last_level && last_level > 1 && n%(2*nstep) == 0)
+          if (level < last_level && last_level > 1 && n%(2*nstep) == 0) {
             nbody->nbodydata[i]->level = last_level - 1;
-          else if (level > last_level)
+          }
+          else if (level > last_level) {
             nbody->nbodydata[i]->level = level;
-          else
+          }
+          else {
             nbody->nbodydata[i]->level = last_level;
+          }
 
           nbody->nbodydata[i]->tlast = t;
           nbody->nbodydata[i]->nlast = n;
@@ -552,42 +555,31 @@ void NbodySimulation<ndim>::ComputeBlockTimesteps(void)
     }
 
 
+    istep = pow(2, level_step - level_max_old + 1);
+
     // Update all timestep variables if we have removed or added any levels
     //---------------------------------------------------------------------------------------------
-    if (level_max != level_max_old) {
-
-      // Increase maximum timestep level if correctly synchronised
-      istep = pow(2,level_step - level_max_old + 1);
-      if (level_max <= level_max_old - 1 && level_max_old > 1 && n%istep == 0)
-        level_max = level_max_old - 1;
-      else if (level_max == level_max_old)
-        level_max = level_max_old;
-
-      // Adjust integer time if levels added or removed
-      if (level_max > level_max_old) {
-        nfactor = pow(2,level_max - level_max_old);
-        n *= nfactor;
-        for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nstep *= nfactor;
-        for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nlast *= nfactor;
-      }
-      else if (level_max < level_max_old) {
-        nfactor = pow(2,level_max_old - level_max);
-        n /= nfactor;
-        for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nlast /= nfactor;
-        for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nstep /= nfactor;
-      }
-
-      // Update values of nstep for both SPH and star particles
-      for (i=0; i<nbody->Nnbody; i++) {
-        if (nbody->nbodydata[i]->nlast == n) nbody->nbodydata[i]->nstep =
-          pow(2,level_step - nbody->nbodydata[i]->level);
-      }
-
-      nresync = pow(2, level_step);
-      timestep = dt_max / (DOUBLE) nresync;
-
+    if (level_max > level_max_old) {
+      nfactor = pow(2, level_max - level_max_old);
+      n *= nfactor;
+      for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nstep *= nfactor;
+      for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nlast *= nfactor;
     }
-    //---------------------------------------------------------------------------------------------
+    else if (level_max <= level_max_old - 1 && level_max_old > 1 && n%istep == 0) {
+      nfactor = pow(2, level_max_old - level_max);
+      n /= nfactor;
+      for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nlast /= nfactor;
+      for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nstep /= nfactor;
+    }
+
+    nresync = pow(2, level_step);
+    timestep = dt_max / (DOUBLE) nresync;
+
+    // Update values of nstep for both SPH and star particles
+    for (i=0; i<nbody->Nnbody; i++) {
+      if (nbody->nbodydata[i]->nlast == n) nbody->nbodydata[i]->nstep =
+        pow(2,level_step - nbody->nbodydata[i]->level);
+    }
 
   }
   //===============================================================================================

--- a/src/Tree/Tree.cpp
+++ b/src/Tree/Tree.cpp
@@ -631,20 +631,16 @@ void Tree<ndim,ParticleType,TreeCell>::ComputeGravityInteractionAndGhostList
 {
   int cc = 0;                          // Cell counter
   FLOAT dr[ndim];                      // Relative position vector
-  FLOAT dr_corr[ndim];                 // Periodic correction vector
   FLOAT rc[ndim];                      // Position of cell
-
-  const GhostNeighbourFinder<ndim> GhostFinder(_domain, cell) ;
-
+  const GhostNeighbourFinder<ndim> GhostFinder(_domain, cell);
   assert(GhostFinder.MaxNumGhosts() == 1) ;
 
   // Make local copies of important cell properties
-  const FLOAT hrangemaxsqd = pow(cell.rmax + kernrange*cell.hmax,2);
-  const FLOAT rmax = cell.rmax;
-  const FLOAT amin = cell.amin;
+  const FLOAT hrangemax = kernrange*cell.hmax;
+  const FLOAT rmax      = cell.rmax;
+  const FLOAT amin      = cell.amin;
   const FLOAT macfactor = cell.macfactor;
   for (int k=0; k<ndim; k++) rc[k] = cell.rcell[k];
-  for (int k=0; k<ndim; k++) dr_corr[k] = 0 ;
 
   // Start with root cell and walk through entire tree
   // Walk through all cells in tree to determine particle and cell interaction lists
@@ -658,8 +654,8 @@ void Tree<ndim,ParticleType,TreeCell>::ComputeGravityInteractionAndGhostList
 
     // Check if bounding spheres overlap with each other (for potential SPH neibs)
     //---------------------------------------------------------------------------------------------
-    if (drsqd <= pow(celldata[cc].rmax + cell.rmax + kernrange*cell.hmax,2) ||
-        drsqd <= pow(cell.rmax + celldata[cc].rmax + kernrange*celldata[cc].hmax,2)) {
+    if (drsqd <= pow(celldata[cc].rmax + rmax + hrangemax, 2) ||
+        drsqd <= pow(rmax + celldata[cc].rmax + kernrange*celldata[cc].hmax,2)) {
 
       // If not a leaf-cell, then open cell to first child cell
       if (celldata[cc].copen != -1) {
@@ -2009,4 +2005,3 @@ template class Tree<3,SM2012SphParticle,BruteForceTreeCell>;
 template class Tree<1,MeshlessFVParticle,BruteForceTreeCell>;
 template class Tree<2,MeshlessFVParticle,BruteForceTreeCell>;
 template class Tree<3,MeshlessFVParticle,BruteForceTreeCell>;
-


### PR DESCRIPTION
Cleans up many compiler warnings by : 
- Removing unused variables
- Setting uninitialised variables to zero/some initial value (may be simply a warning but could potentially be actual bugs)
- Cast some unsigned int variables to ints to prevent int/unsigned comparison warnings (used C-style casts; these are mainly from STL size/length functions that return unsigned ints)

This also includes the uninitialised variables in the Riemann solver that were causing issues before.  I've tested it on a sample of the test suite so now will see how it performs with Travis to check everything else.  

There are still two main files/modules that are producing mass warnings, namely the Multiple Source Radiation class and the TreeRay class.  Both of these will be addressed in separate commits in the future.

There was one final warning I was not sure what it was doing exactly so left it alone.  This is a warning regarding some 'reinterpret_cast<SNAPFLOAT&>' statements in SphSnapshot.cpp.  I'll leave this one alone to whoever wrote this code!