### PR TITLE
Fixed bug with periodic boundaries

### DIFF
--- a/src/GradhSph/GradhSphTree.cpp
+++ b/src/GradhSph/GradhSphTree.cpp
@@ -397,6 +397,11 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphHydroForces
           NeighbourList<HydroParticle> neiblist =
               neibmanager.GetParticleNeib(activepart[j],hydromask,do_pair_once);
 
+#if defined(VERIFY_ALL)
+          neibmanager.VerifyNeighbourList(i, sph->Nhydro, sphdata, "all");
+          neibmanager.VerifyReducedNeighbourList(i, neiblist, sph->Nhydro, sphdata, "all");
+#endif
+
           // Compute all neighbour contributions to hydro forces
           typename ParticleType<ndim>::HydroMethod* method = (typename ParticleType<ndim>::HydroMethod*) sph;
           method->ComputeSphHydroForces(activepart[j],neiblist);

--- a/src/Headers/GhostNeighbours.hpp
+++ b/src/Headers/GhostNeighbours.hpp
@@ -151,12 +151,12 @@ public:
 	   	  for (int k=0; k<ndim; k++)
 	   	    if (_periodic_bound[k]) {
 	   	      if (dr[k] > _domain.half[k]) {
-	   	        dr[k]  = - _domain.size[k];
+	   	        dr[k] += - _domain.size[k];
 	   	        r[k]  += - _domain.size[k];
 	   	        bound.set_flag(periodic_bound_flags[k][1]) ;
 	   	      }
 	   	      else if (dr[k] < -_domain.half[k]) {
-	   	        dr[k]  = _domain.size[k];
+	   	        dr[k] += _domain.size[k];
 	   	        r[k]  += _domain.size[k] ;
 	   	        bound.set_flag(periodic_bound_flags[k][0]) ;
 	   	      }

--- a/src/Headers/NeighbourManager.h
+++ b/src/Headers/NeighbourManager.h
@@ -18,6 +18,10 @@ using namespace std;
 #include "Particle.h"
 
 
+// Fwd declare
+template<int ndim, class ParticleType> class NeighbourManager;
+
+
 //=================================================================================================
 //  Class NeighbourIterator
 /// \brief   Template class for iterating of neighbour lists.
@@ -157,7 +161,13 @@ public:
     return _neibpart[_idx[i]];
   }
 
+  template <class InParticleType>
+  void VerifyNeighbourList(int i, int Ntot, const InParticleType& partdata,
+                           const string& searchmode) ;
+
 private:
+  template<int ndim, class PartType> friend class NeighbourManager;
+
   std::vector<int>& _idx;
   std::vector<ParticleType>& _neibpart;
 };
@@ -390,7 +400,7 @@ private:
     }
 
     assert(directlist.size() == neibdata.size() &&
-          neib_idx.size()   == neibdata.size());
+           neib_idx.size()   == neibdata.size());
 
     // Now look at the hydro candidate neighbours
     // First the ones that need ghosts to be created on the fly
@@ -481,32 +491,33 @@ private:
 
     // Go through the hydro neighbour candidates and check the distance. The ones that are not real neighbours
     // are demoted to the direct list
-    for (int jj=0; jj < neiblist.size(); jj++) {
-      int ii = neiblist[jj];
+    for (int j=0; j < neiblist.size(); j++) {
+      int i = neiblist[j];
+      ParticleType& neibpart = neibdata[i] ;
 
       // If do_pair_once is true then only get the neighbour for the first of the two times the
-      if (not _first_appearance(p, neibdata[ii], do_pair_once())) continue;
+      if (not _first_appearance(p, neibpart, do_pair_once())) continue;
 
       // Compute relative position and distance quantities for pair
-      for (int k=0; k<ndim; k++) draux[k] = neibdata[ii].r[k] - rp[k];
-      if (jj < _NPeriodicGhosts && hydromask[neibdata[ii].ptype])
-        GhostFinder.ApplyPeriodicDistanceCorrection(neibdata[ii].r, draux);
+      for (int k=0; k<ndim; k++) draux[k] = neibpart.r[k] - rp[k];
+      if (j < _NPeriodicGhosts && hydromask[neibpart.ptype])
+        GhostFinder.ApplyPeriodicDistanceCorrection(neibpart.r, draux);
 
-      const FLOAT drsqd = DotProduct(draux,draux,ndim) + small_number;
+      const FLOAT drsqd = DotProduct(draux,draux,ndim);
 
       //if (drsqd <= small_number) continue;
 
       // Record if neighbour is direct-sum or and SPH neighbour.
       // If SPH neighbour, also record max. timestep level for neighbour
-      if (drsqd > hrangesqdi && drsqd >= neibdata[ii].hrangesqd) {
-        if (keep_grav && gravmask[neibdata[ii].ptype]) directlist.push_back(ii);
+      if (drsqd >= hrangesqdi && drsqd >= neibpart.hrangesqd) {
+        if (keep_grav && gravmask[neibpart.ptype]) directlist.push_back(i);
       }
       else {
-        if (hydromask[neibdata[ii].ptype]){
-          culled_neiblist.push_back(ii);
+        if (hydromask[neibpart.ptype]){
+          culled_neiblist.push_back(i);
         }
-        else if (keep_grav && gravmask[neibdata[ii].ptype]) {
-          smoothgravlist.push_back(ii);
+        else if (keep_grav && gravmask[neibpart.ptype]) {
+          smoothgravlist.push_back(i);
         }
       }
     }
@@ -543,13 +554,50 @@ public:
   template <class InParticleType>
   void VerifyNeighbourList(int i, int Ntot, const InParticleType& partdata,
                            const string& searchmode) {
-    std::vector<int> truengb ;
-    FLOAT drsqd ;
-    FLOAT dr[ndim];
 
-    const GhostNeighbourFinder<ndim> GhostFinder(*_domain);
+    std::vector<int> reducedngb = neib_idx ;
+    __VerifyNeighbourList(i, reducedngb, Ntot, partdata, searchmode, "all") ;
+  }
 
-    if (searchmode == "gather") {
+  //===============================================================================================
+  //  VerifyReducedNeighbourList
+  /// \brief    Verify the list of neighbours is complete.
+  /// \details  Checks whether the list of neighbours held by the passed list object is complete.
+  ///           Currently only works for full scatter/gather neigbours, does not take into account
+  ///           the missing neighbours for flux calculations.
+  //===============================================================================================
+   template <class InParticleType>
+   void VerifyReducedNeighbourList(int i, const NeighbourList<ParticleType>& ngbs,
+                                   int Ntot, const InParticleType& partdata,
+                                   const string& searchmode) {
+
+     // Get the idx of the reduced neighbour list
+     std::vector<int> reducedngb(ngbs.size());
+     for (int k=0; k<ngbs.size(); k++)
+       reducedngb[k] = neib_idx[ngbs._idx[k]];
+
+     __VerifyNeighbourList(i, reducedngb, Ntot, partdata, searchmode, "reduced") ;
+   }
+
+   //===============================================================================================
+   //  __VerifyNeighbourList
+   /// \brief    Verify the list of neighbours is complete.
+   /// \details  Compares a list of neighbour indexes (locations in particle array) to the list of
+   ///           neighbours found by a brute-force comparison to check whether any neighbours have
+   ///           been missed.
+   //===============================================================================================
+   template <class InParticleType>
+   void __VerifyNeighbourList(int i, std::vector<int>& reducedngb,
+                              int Ntot, const InParticleType& partdata,
+                              const string& searchmode, const string& listtype) {
+     std::vector<int> truengb ;
+     FLOAT drsqd ;
+     FLOAT dr[ndim];
+
+     const GhostNeighbourFinder<ndim> GhostFinder(*_domain);
+
+     // Compute the complete (true) list of neighbours
+     if (searchmode == "gather") {
        for (int j=0; j<Ntot; j++) {
          for (int k=0; k<ndim; k++) dr[k] = partdata[j].r[k] - partdata[i].r[k];
          GhostFinder.NearestPeriodicVector(dr);
@@ -562,48 +610,48 @@ public:
          for (int k=0; k<ndim; k++) dr[k] = partdata[j].r[k] - partdata[i].r[k];
          GhostFinder.NearestPeriodicVector(dr);
          drsqd = DotProduct(dr,dr,ndim);
-         if (drsqd < partdata[i].hrangesqd ||
-             drsqd < partdata[j].hrangesqd) truengb.push_back(j);
+         if (drsqd <= partdata[i].hrangesqd ||
+             drsqd <= partdata[j].hrangesqd) truengb.push_back(j);
        }
      }
 
-    // Now compare each given neighbour with true neighbour list for validation
-    int invalid_flag = 0, j ;
-    for (j=0; j<truengb.size(); j++) {
-      int count = 0;
-      for (int k=0; k<neib_idx.size(); k++)
-        if (neib_idx[k] == truengb[j])
-          count++;
+     // Now compare each given neighbour with true neighbour list for validation
+     int invalid_flag = 0, j ;
+     for (j=0; j<truengb.size(); j++) {
+       int count = 0;
+       for (int k=0; k<reducedngb.size(); k++)
+         if (reducedngb[k] == truengb[j])
+           count++;
 
-      // If the true neighbour is not in the list, or included multiple times,
-      // then output to screen and terminate program
-      if (count != 1) {
-        for (int k=0; k<ndim; k++) dr[k] = partdata[truengb[j]].r[k] - partdata[i].r[k];
-        drsqd = DotProduct(dr,dr,ndim);
-        cout << "Could not find neighbour " << j << "   " << truengb[j] << "     " << i
-            << "      " << sqrt(drsqd)/sqrt(partdata[i].hrangesqd) << "     "
-            << sqrt(drsqd)/sqrt(partdata[j].hrangesqd) << "    "
-            << partdata[truengb[j]].r[0] << "   type : "
-            << partdata[truengb[j]].ptype << endl;
-        invalid_flag++;
-      }
+       // If the true neighbour is not in the list, or included multiple times,
+       // then output to screen and terminate program
+       if (count != 1) {
+         for (int k=0; k<ndim; k++) dr[k] = partdata[truengb[j]].r[k] - partdata[i].r[k];
+         GhostFinder.NearestPeriodicVector(dr);
+         drsqd = DotProduct(dr,dr,ndim);
+         cout << "Could not find neighbour " << j << "   " << truengb[j] << "     " << i
+             << "      " << sqrt(drsqd)/sqrt(partdata[i].hrangesqd) << "     "
+             << sqrt(drsqd)/sqrt(partdata[j].hrangesqd) << "    "
+             << partdata[truengb[j]].r[0] << "   type : "
+             << partdata[truengb[j]].ptype << endl;
+         invalid_flag++;
+       }
 
-    }
-    // If the true neighbour is not in the list, or included multiple times,
-    // then output to screen and terminate program
-    if (invalid_flag) {
-      cout << "Problem with neighbour lists : " << i << "  " << j << "   "
-          <<  invalid_flag << "    " << partdata[i].r[0] << "   " << partdata[i].h << endl
-          << "Nneib : " << neib_idx.size() << "   Ntrueneib : " << truengb.size()
-          << "    searchmode : " << searchmode << endl;
-      InsertionSort(neib_idx.size(), &neib_idx[0]);
-      PrintArray("neiblist     : ",neib_idx.size(), &neib_idx[0]);
-      PrintArray("trueneiblist : ",truengb.size() , &truengb[0]);
-      string message = "Problem with neighbour lists in tree search";
-      ExceptionHandler::getIstance().raise(message);
-    }
-  }
-
+     }
+     // If the true neighbour is not in the list, or included multiple times,
+     // then output to screen and terminate program
+     if (invalid_flag) {
+       cout << "Problem with neighbour lists (" << listtype << ") : " << i << "  " << j << "   "
+           <<  invalid_flag << "    " << partdata[i].r[0] << "   " << partdata[i].h << endl
+           << "Nneib : " << neib_idx.size() << "   Ntrueneib : " << truengb.size()
+           << "    searchmode : " << searchmode << endl;
+       InsertionSort(reducedngb.size(), &reducedngb[0]);
+       PrintArray("neiblist     : ",reducedngb.size(), &reducedngb[0]);
+       PrintArray("trueneiblist : ",truengb.size() , &truengb[0]);
+       string message = "Problem with neighbour lists in tree search";
+       ExceptionHandler::getIstance().raise(message);
+     }
+   }
 };
 
 

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -420,6 +420,7 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGradientMatrices
 
 #if defined(VERIFY_ALL)
         neibmanager.VerifyNeighbourList(i, mfv->Nhydro, mfvdata, "all");
+        neibmanager.VerifyReducedNeighbourList(i, neiblist, mfv->Nhydro, mfvdata, "all");
 #endif
         // Compute all neighbour contributions to gradients
         mfv->ComputeGradients(activepart[j], neiblist);


### PR DESCRIPTION
I've fixed a bug related to the neighbour search when periodic boundaries are used. In doing this, I have used the neighbour manager to reinstate the validation of the neighbour lists, which is working nicely where it is applicable.