### PR TITLE
Fixed bug with star gravity in SPH

### DIFF
--- a/src/GradhSph/GradhSphTree.cpp
+++ b/src/GradhSph/GradhSphTree.cpp
@@ -428,6 +428,8 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphHydroForces
       for (int j=0; j<Nactive; j++) {
         const int i = activelist[j];
         for (int k=0; k<ndim; k++) sphdata[i].a[k] += activepart[j].a[k];
+        for (int k=0; k<ndim; k++) sphdata[i].a[k]     += activepart[j].atree[k];
+        for (int k=0; k<ndim; k++) sphdata[i].atree[k] += activepart[j].atree[k];
         sphdata[i].gpot     += activepart[j].gpot;
         sphdata[i].dudt     += activepart[j].dudt;
         sphdata[i].dalphadt += activepart[j].dalphadt;


### PR DESCRIPTION
I've fixed a bug where the gravity of the stars was missing in SPH when self-gravity was switched off