### PR TITLE
Uninitialised and unused variables

### DIFF
--- a/src/Common/Dust.cpp
+++ b/src/Common/Dust.cpp
@@ -563,8 +563,6 @@ void DustSphNgbFinder<ndim, ParticleType>::FindNeibAndDoForces
 #endif
       neibmanager.EndSearch(cell,sphdata);
 
-      //const int Nneib_cell = neibmanager.GetNumAllNeib();
-
       // Loop over all active particles in the cell
       //-------------------------------------------------------------------------------------------
       for (j=0; j<Nactive; j++) {

--- a/src/Common/Dust.cpp
+++ b/src/Common/Dust.cpp
@@ -531,7 +531,6 @@ void DustSphNgbFinder<ndim, ParticleType>::FindNeibAndDoForces
     int cc;                                      // Aux. cell counter
     int i;                                       // Particle id
     int j;                                       // Aux. particle counter
-    int jj;                                      // Aux. particle counter
     int k;                                       // Dimension counter
     int Nactive;                                 // ..
     vector<int>                 activelist(_tree->MaxNumPartInLeafCell()); // Ids of Active parts

--- a/src/Common/Dust.cpp
+++ b/src/Common/Dust.cpp
@@ -563,7 +563,7 @@ void DustSphNgbFinder<ndim, ParticleType>::FindNeibAndDoForces
 #endif
       neibmanager.EndSearch(cell,sphdata);
 
-      const int Nneib_cell = neibmanager.GetNumAllNeib();
+      //const int Nneib_cell = neibmanager.GetNumAllNeib();
 
       // Loop over all active particles in the cell
       //-------------------------------------------------------------------------------------------

--- a/src/Feedback/Supernova.cpp
+++ b/src/Feedback/Supernova.cpp
@@ -154,8 +154,7 @@ void Supernova<ndim>::SupernovaInjection
     for (k=0; k<ndim; k++) vpart[k] = (rpart[k] - SNpos[k])/drmag * vrad_mag;
 
     // Get new particle i
-    //Particle<ndim> &part =
-      hydro->CreateNewParticle(gas_type, hydro->mmean, uinj, rpart, vpart, sim);
+    hydro->CreateNewParticle(gas_type, hydro->mmean, uinj, rpart, vpart, sim);
 
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/Feedback/Supernova.cpp
+++ b/src/Feedback/Supernova.cpp
@@ -68,7 +68,6 @@ void Supernova<ndim>::SupernovaInjection
   int i;                                     // ..
   int j;                                     // ..
   int k;                                     // ..
-  int id;                                    // ..
   int Ninject = (int) (Minj/hydro->mmean);   // No. of new hydro ptcls to inject as hot SN gas
   int Nneib;                                 // ..
   int Nneibmax = 100;                        // ..
@@ -155,8 +154,8 @@ void Supernova<ndim>::SupernovaInjection
     for (k=0; k<ndim; k++) vpart[k] = (rpart[k] - SNpos[k])/drmag * vrad_mag;
 
     // Get new particle i
-    Particle<ndim> &part = hydro->CreateNewParticle
-      (gas_type, hydro->mmean, uinj, rpart, vpart, sim);
+    //Particle<ndim> &part =
+      hydro->CreateNewParticle(gas_type, hydro->mmean, uinj, rpart, vpart, sim);
 
   }
   //-----------------------------------------------------------------------------------------------

--- a/src/Feedback/SupernovaDriver.cpp
+++ b/src/Feedback/SupernovaDriver.cpp
@@ -160,7 +160,6 @@ SilccSupernovaDriver<ndim>::SilccSupernovaDriver
  (SimulationBase* sim, Parameters *params, SimUnits &units) : SupernovaDriver<ndim>(sim)
 {
   // Local references to parameter variables for brevity
-  //map<string, int> &intparams = params->intparams;
   map<string, double> &floatparams = params->floatparams;
   map<string, string> &stringparams = params->stringparams;
 

--- a/src/Feedback/SupernovaDriver.cpp
+++ b/src/Feedback/SupernovaDriver.cpp
@@ -49,11 +49,6 @@ template <int ndim>
 SedovTestDriver<ndim>::SedovTestDriver
  (SimulationBase* sim, Parameters *params, SimUnits &units) : SupernovaDriver<ndim>(sim)
 {
-  // Local references to parameter variables for brevity
-  map<string, int> &intparams = params->intparams;
-  map<string, double> &floatparams = params->floatparams;
-  map<string, string> &stringparams = params->stringparams;
-
   tsupernova = 1.0;
 }
 
@@ -105,16 +100,12 @@ void SedovTestDriver<ndim>::Update
 //=================================================================================================
 template <int ndim>
 RandomSedovTestDriver<ndim>::RandomSedovTestDriver
- (SimulationBase* sim, Parameters *params, SimUnits &units, DomainBox<ndim> &_simbox) : SupernovaDriver<ndim>(sim)
+ (SimulationBase* sim, Parameters *params, SimUnits &units, DomainBox<ndim> &_simbox) :
+  SupernovaDriver<ndim>(sim)
 {
-  // Local references to parameter variables for brevity
-  map<string, int> &intparams = params->intparams;
-  map<string, double> &floatparams = params->floatparams;
-  map<string, string> &stringparams = params->stringparams;
-
   tsupernova = 0.5;
-  tnext = 0.5*tsupernova;
-  simbox = &(_simbox);
+  tnext      = 0.5*tsupernova;
+  simbox     = &(_simbox);
 }
 
 
@@ -169,7 +160,7 @@ SilccSupernovaDriver<ndim>::SilccSupernovaDriver
  (SimulationBase* sim, Parameters *params, SimUnits &units) : SupernovaDriver<ndim>(sim)
 {
   // Local references to parameter variables for brevity
-  map<string, int> &intparams = params->intparams;
+  //map<string, int> &intparams = params->intparams;
   map<string, double> &floatparams = params->floatparams;
   map<string, string> &stringparams = params->stringparams;
 

--- a/src/GradhSph/GradhSphTree.cpp
+++ b/src/GradhSph/GradhSphTree.cpp
@@ -109,7 +109,7 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphProperties
 
   // Set-up all OMP threads
   //===============================================================================================
-#pragma omp parallel default(none) shared(cactive,celllist,cout,nbody,sph,sphdata,Ntot)
+#pragma omp parallel default(none) shared(cactive,celllist,cout,nbody,sph,sphdata)
   {
 #if defined _OPENMP
     const int ithread = omp_get_thread_num();

--- a/src/GradhSph/GradhSphTree.cpp
+++ b/src/GradhSph/GradhSphTree.cpp
@@ -85,7 +85,7 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphProperties
 {
   int cactive;                             // No. of active tree cells
   vector<TreeCellBase<ndim> > celllist;		   // List of active tree cells
-
+  ParticleType<ndim>* sphdata = reinterpret_cast<ParticleType<ndim>*> (sph->GetSphParticleArray());
 #ifdef MPI_PARALLEL
   double twork = timing->RunningTime();  // Start time (for load balancing)
 #endif
@@ -93,18 +93,12 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphProperties
   debug2("[GradhSphTree::UpdateAllSphProperties]");
   CodeTiming::BlockTimer timer = timing->StartNewTimer("SPH_PROPERTIES");
 
-  int Ntot = sph->Ntot;
-  ParticleType<ndim>* sphdata =
-      reinterpret_cast<ParticleType<ndim>*> (sph->GetSphParticleArray());
-
   // Find list of all cells that contain active particles
   cactive = tree->ComputeActiveCellList(celllist);
   assert(cactive <= tree->gtot);
 
   // If there are no active cells, return to main loop
-  if (cactive == 0) {
-    return;
-  }
+  if (cactive == 0) return;
 
 
   // Set-up all OMP threads
@@ -288,7 +282,7 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphProperties
 #ifdef MPI_PARALLEL
   twork = timing->RunningTime() - twork;
   int Nactivetot=0;
-  tree->AddWorkCost(celllist, twork, Nactivetot) ;
+  tree->AddWorkCost(celllist, twork, Nactivetot);
 #ifdef OUTPUT_ALL
   cout << "Time computing smoothing lengths : " << twork << "     Nactivetot : " << Nactivetot << endl;
 #endif
@@ -314,8 +308,8 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphHydroForces
   DomainBox<ndim> &simbox)                 ///< [in] Simulation domain box
 {
   int cactive;                             // No. of active cells
-  vector<TreeCellBase<ndim> > celllist;                // List of active tree cells
-
+  vector<TreeCellBase<ndim> > celllist;    // List of active tree cells
+  ParticleType<ndim>* sphdata = reinterpret_cast<ParticleType<ndim>*> (sph->GetSphParticleArray());
 #ifdef MPI_PARALLEL
   double twork = timing->RunningTime();  // Start time (for load balancing)
 #endif
@@ -324,20 +318,16 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphHydroForces
   CodeTiming::BlockTimer timer = timing->StartNewTimer("SPH_HYDRO_FORCES");
 
   // Make sure we have enough neibmanagers
-  for (int t = neibmanagerbufhydro.size(); t < Nthreads; ++t)
+  for (int t = neibmanagerbufhydro.size(); t < Nthreads; ++t) {
     neibmanagerbufhydro.push_back(NeighbourManagerHydro(sph, simbox));
-
-  ParticleType<ndim>* sphdata =
-      reinterpret_cast<ParticleType<ndim>*> (sph->GetSphParticleArray());
-
+  }
 
   // Find list of all cells that contain active particles
   cactive = tree->ComputeActiveCellList(celllist);
 
   // If there are no active cells, return to main loop
-  if (cactive == 0) {
-    return;
-  }
+  if (cactive == 0) return;
+
 
   // Set-up all OMP threads
   //===============================================================================================
@@ -386,14 +376,11 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphHydroForces
       // Loop over all active particles in the cell
       //-------------------------------------------------------------------------------------------
       for (int j=0; j<Nactive; j++) {
-        const int i = activelist[j];
+        bool do_hydro = sph->types[activepart[j].ptype].hydro_forces;
 
-        bool do_hydro = sph->types[activepart[j].ptype].hydro_forces ;
-        if (do_hydro){
+        if (do_hydro) {
           Typemask hydromask  = sph->types[activepart[j].ptype].hydromask;
-
-          const bool do_pair_once=false;
-
+          const bool do_pair_once = false;
           NeighbourList<HydroParticle> neiblist =
               neibmanager.GetParticleNeib(activepart[j],hydromask,do_pair_once);
 
@@ -412,11 +399,11 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphHydroForces
       // Update levelneib for neighbours
       const int Nneib_cell = neibmanager.GetNumAllNeib();
       for (int jj=0; jj<Nneib_cell; jj++) {
-    	std::pair<int,HydroParticle*> neighbour=neibmanager.GetNeibI(jj);
-    	const int i=neighbour.first;
-    	HydroParticle& neibpart=*(neighbour.second);
-    	levelneib[i]=max(levelneib[i],neibpart.levelneib);
-       }
+        std::pair<int,HydroParticle*> neighbour=neibmanager.GetNeibI(jj);
+        const int i=neighbour.first;
+        HydroParticle& neibpart=*(neighbour.second);
+        levelneib[i]=max(levelneib[i],neibpart.levelneib);
+      }
 
 
       // Compute all star forces for active particles
@@ -486,7 +473,7 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
 {
   int cactive;                         // No. of active cells
   vector<TreeCellBase<ndim> > celllist;            // List of active cells
-
+  ParticleType<ndim>* sphdata = reinterpret_cast<ParticleType<ndim>*> (sph->GetSphParticleArray());
 #ifdef MPI_PARALLEL
   double twork = timing->RunningTime();  // Start time (for load balancing)
 #endif
@@ -495,19 +482,15 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
   CodeTiming::BlockTimer timer = timing->StartNewTimer("SPH_ALL_FORCES");
 
   // Make sure we have enough neibmanagers
-  for (int t = neibmanagerbufhydro.size(); t < Nthreads; ++t)
+  for (int t = neibmanagerbufhydro.size(); t < Nthreads; ++t) {
     neibmanagerbufhydro.push_back(NeighbourManagerHydro(sph, simbox));
-
-  ParticleType<ndim>* sphdata =
-      reinterpret_cast<ParticleType<ndim>*> (sph->GetSphParticleArray());
+  }
 
   // Find list of all cells that contain active particles
   cactive = tree->ComputeActiveCellList(celllist);
 
   // If there are no active cells, return to main loop
-  if (cactive == 0) {
-    return;
-  }
+  if (cactive == 0) return;
 
 
   // Set-up all OMP threads
@@ -566,22 +549,20 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
       // Loop over all active particles in the cell
       //-------------------------------------------------------------------------------------------
       for (int j=0; j<Nactive; j++) {
-        const int i = activelist[j];
-
         const bool do_grav  = sph->types[activepart[j].ptype].self_gravity ;
         Typemask hydromask = sph->types[activepart[j].ptype].hydromask ;
-
         GravityNeighbourLists<HydroParticle> neiblists =
             neibmanager.GetParticleNeibGravity(activepart[j],hydromask);
-
 
         // Compute forces between SPH neighbours (hydro and gravity)
         typename ParticleType<ndim>::HydroMethod* method = (typename ParticleType<ndim>::HydroMethod*) sph;
 
-        if (neiblists.neiblist.size() > 0)
+        if (neiblists.neiblist.size() > 0) {
           method->ComputeSphHydroGravForces(activepart[j], neiblists.neiblist);
+        }
 
-        if (do_grav){
+        if (do_grav) {
+
           // Compute soften grav forces between non-SPH neighbours (hydro and gravity)
           method->ComputeSphGravForces(activepart[j], neiblists.smooth_gravlist);
 
@@ -599,12 +580,12 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
          }
 
           // Add the periodic correction force for SPH and direct-sum neighbours
-          if (simbox.PeriodicGravity){
-            int Ntotneib = neibmanager.GetNumAllNeib() ;
+          if (simbox.PeriodicGravity) {
+            int Ntotneib = neibmanager.GetNumAllNeib();
 
             for (int jj=0; jj< Ntotneib; jj++) {
 
-        	  if (!gravmask[neibmanager[jj].ptype]) continue ;
+            if (!gravmask[neibmanager[jj].ptype]) continue;
 
               FLOAT draux[ndim];
               for (int k=0; k<ndim; k++) draux[k] = neibmanager[jj].r[k] - activepart[j].r[k];
@@ -702,4 +683,3 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
 template class GradhSphTree<1,GradhSphParticle>;
 template class GradhSphTree<2,GradhSphParticle>;
 template class GradhSphTree<3,GradhSphParticle>;
-

--- a/src/Headers/GhostNeighbours.hpp
+++ b/src/Headers/GhostNeighbours.hpp
@@ -413,8 +413,8 @@ private:
 	  const int old_size = ngbs.size()-1;
 	  const ParticleType& real_particle = ngbs.back();
 	  FLOAT h2 = real_particle.hrangesqd ;
-	  FLOAT r[ndim];
-	  for (int k=0; k<ndim; k++) r[k]=real_particle.r[k];
+	  //FLOAT r[ndim];
+	  //for (int k=0; k<ndim; k++) r[k]=real_particle.r[k];
 
 	  // Loop over the possible directions for reflections
 	  for (int k = 0; k < ndim; k++){

--- a/src/Headers/GhostNeighbours.hpp
+++ b/src/Headers/GhostNeighbours.hpp
@@ -413,8 +413,6 @@ private:
 	  const int old_size = ngbs.size()-1;
 	  const ParticleType& real_particle = ngbs.back();
 	  FLOAT h2 = real_particle.hrangesqd ;
-	  //FLOAT r[ndim];
-	  //for (int k=0; k<ndim; k++) r[k]=real_particle.r[k];
 
 	  // Loop over the possible directions for reflections
 	  for (int k = 0; k < ndim; k++){

--- a/src/Headers/Ic.h
+++ b/src/Headers/Ic.h
@@ -1118,7 +1118,6 @@ public:
       const FLOAT hfactor = pow(invh, ndim);
       const FLOAT dV      = pow(2.0*hrange/(FLOAT) gridSize, ndim);
       FLOAT sumValue      = (FLOAT) 0.0;
-      //FLOAT lengthmax     = (FLOAT) 0.0;
       FLOAT dr[ndim];
       FLOAT drsqd;
       FLOAT r[ndim];

--- a/src/Headers/Ic.h
+++ b/src/Headers/Ic.h
@@ -1118,7 +1118,7 @@ public:
       const FLOAT hfactor = pow(invh, ndim);
       const FLOAT dV      = pow(2.0*hrange/(FLOAT) gridSize, ndim);
       FLOAT sumValue      = (FLOAT) 0.0;
-      FLOAT lengthmax     = (FLOAT) 0.0;
+      //FLOAT lengthmax     = (FLOAT) 0.0;
       FLOAT dr[ndim];
       FLOAT drsqd;
       FLOAT r[ndim];

--- a/src/Headers/NeighbourManager.h
+++ b/src/Headers/NeighbourManager.h
@@ -342,7 +342,7 @@ public:
    {
     TrimNeighbourLists<InParticleType,_false_type>(p, hydromask, true);
 
-    assert((culled_neiblist.size()+directlist.size()+smoothgravlist.size()) == GetNumAllNeib());
+    assert((int) (culled_neiblist.size()+directlist.size()+smoothgravlist.size()) == GetNumAllNeib());
 
 
     typedef typename GravityNeighbourLists<ParticleType>::DirectType DirectType ;

--- a/src/Headers/NeighbourManager.h
+++ b/src/Headers/NeighbourManager.h
@@ -392,7 +392,7 @@ private:
 
     // Start from direct neighbours
     if (keep_direct) {
-      for (int ii=0; ii< tempdirectneib.size(); ii++) {
+      for (int ii=0; ii<(int) tempdirectneib.size(); ii++) {
         const int i = tempdirectneib[ii];
         const InParticleType& part = partdata[i];
         // Forget immediately: direct particles and particles that do not interact gravitationally
@@ -412,13 +412,13 @@ private:
     // Now look at the hydro candidate neighbours
     // First the ones that need ghosts to be created on the fly
     int Nneib = directlist.size();
-    for (int ii=0; ii < tempperneib.size(); ii++) {
+    for (int ii=0; ii<(int) tempperneib.size(); ii++) {
       const int i = tempperneib[ii];
       if (partdata[i].flags.is_dead()) continue;
 
       GhostFinder.ConstructGhostsScatterGather(partdata[i], neibdata);
 
-      while (Nneib < neibdata.size()) {
+      while (Nneib < (int) neibdata.size()) {
         int Nmax = neibdata.size();
         for (int k=0; k<ndim; k++) dr[k] = neibdata[Nneib].r[k] - rc[k];
         drsqd = DotProduct(dr, dr, ndim);
@@ -435,8 +435,7 @@ private:
         }
         else if (Nmax > Nneib) {
           Nmax--;
-          if (Nmax > Nneib)
-            neibdata[Nneib] = neibdata[Nmax];
+          if (Nmax > Nneib) neibdata[Nneib] = neibdata[Nmax];
           neibdata.resize(neibdata.size()-1);
         }
       }// Loop over Ghosts
@@ -446,7 +445,7 @@ private:
     _NPeriodicGhosts = neiblist.size();
 
     // Find those particles that do not need ghosts on the fly
-    for (int ii=0; ii<tempneib.size(); ii++) {
+    for (int ii=0; ii<(int) tempneib.size(); ii++) {
       const int i = tempneib[ii];
       if (partdata[i].flags.is_dead()) continue;
 
@@ -498,7 +497,7 @@ private:
 
     // Go through the hydro neighbour candidates and check the distance. The ones that are not real neighbours
     // are demoted to the direct list
-    for (int j=0; j < neiblist.size(); j++) {
+    for (int j=0; j<(int) neiblist.size(); j++) {
       int i = neiblist[j];
       ParticleType& neibpart = neibdata[i] ;
 

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -62,12 +62,7 @@ Hydrodynamics<ndim>::Hydrodynamics(int hydro_forces_aux, int self_gravity_aux, F
   types(params),
   kerntab(TabulatedKernel<ndim>(KernelName))
 {
-  // Local references to parameter variables for brevity
-  map<string, int> &intparams = params->intparams;
-  map<string, double> &floatparams = params->floatparams;
-  map<string, string> &stringparams = params->stringparams;
-  string gas_radiation = stringparams["radiation"];
-
+  const std::string gas_radiation = params->stringparams["radiation"];
 
   // Zero or initialise all common Hydrodynamics variables
   //-----------------------------------------------------------------------------------------------
@@ -77,7 +72,7 @@ Hydrodynamics<ndim>::Hydrodynamics(int hydro_forces_aux, int self_gravity_aux, F
   NImportedParticles = 0;
   Nmpighost          = 0;
   NPeriodicGhost     = 0;
-  create_sinks       = intparams["create_sinks"];
+  create_sinks       = params->intparams["create_sinks"];
 
   // Select and construct equation of state object from given parameters
   //-----------------------------------------------------------------------------------------------

--- a/src/Hydrodynamics/RiemannSolver.cpp
+++ b/src/Hydrodynamics/RiemannSolver.cpp
@@ -238,12 +238,13 @@ void ExactRiemannSolver<ndim>::ComputeStarRegion
     else if (2.0*fabs(pstar - pold)/(pstar + pold) < tolerance) break;
 
     // Check the star variables have not become NaNs
-    if (pstar != pstar) {
-      std::cout << "Checking Riemann values : " << pstar << "   "
-                << ustar << "   iteration : " << iteration << std::endl;
+    if (!isfinite(pstar)) {
+      std::cout << "Checking Riemann values : " << pstar
+                << "   iteration : " << iteration << std::endl;
       std::cout << "rho : " << dl << "   " << dr << "     vel : " << ul << "    "
                 << ur << "    press : " << pl << "    " << pr << std::endl;
-      std::cout << "f/fprime : " << fl << "   " << fr << "   " << flprime << "   " << frprime << endl;
+      std::cout << "f/fprime : " << fl << "   " << fr
+                << "   " << flprime << "   " << frprime << endl;
       ExceptionHandler::getIstance().raise("Error : Invalid star values in Riemann solver");
     }
 
@@ -436,14 +437,14 @@ void ExactRiemannSolver<ndim>::ComputeFluxes
   const FLOAT cl = sqrt(gamma*Wleft[ipress]/Wleft[irho]);      // LHS sound speed
   const FLOAT cr = sqrt(gamma*Wright[ipress]/Wright[irho]);    // RHS sound speed
   int k,kv;                            // Dimension counters
-  FLOAT pstar;                         // Pressure in star region
-  FLOAT ustar;                         // Velocity in star region
   FLOAT p,d,u;                         // Primitive variables at s=0 from Riemann solver
   FLOAT rotMat[ndim][ndim];            // Rotation matrix
   FLOAT invRotMat[ndim][ndim];         // Inverse rotation matrix
   FLOAT uleft[ndim];                   // Left velocity state
   FLOAT uright[ndim];                  // Right velocity state
   FLOAT Wface[nvar];                   // Primitive vector at working face
+  FLOAT pstar = small_number;          // Pressure in star region
+  FLOAT ustar = (FLOAT) 0.0;           // Velocity in star region
 
   assert(Wleft[ipress] > 0.0);
   assert(Wleft[irho] > 0.0);

--- a/src/Ic/Ic.cpp
+++ b/src/Ic/Ic.cpp
@@ -117,7 +117,7 @@ FLOAT Ic<ndim>::GetSmoothedDensity
   const FLOAT hfactor = pow(invh, ndim);
   const FLOAT dV      = pow(2.0*hrange/(FLOAT) gridSize, ndim);
   FLOAT sumValue      = (FLOAT) 0.0;
-  FLOAT lengthmax     = (FLOAT) 0.0;
+  //FLOAT lengthmax     = (FLOAT) 0.0;
   FLOAT dr[ndim];
   FLOAT drsqd;
   FLOAT r[ndim];

--- a/src/Ic/Ic.cpp
+++ b/src/Ic/Ic.cpp
@@ -117,7 +117,6 @@ FLOAT Ic<ndim>::GetSmoothedDensity
   const FLOAT hfactor = pow(invh, ndim);
   const FLOAT dV      = pow(2.0*hrange/(FLOAT) gridSize, ndim);
   FLOAT sumValue      = (FLOAT) 0.0;
-  //FLOAT lengthmax     = (FLOAT) 0.0;
   FLOAT dr[ndim];
   FLOAT drsqd;
   FLOAT r[ndim];

--- a/src/Ic/PolytropeIc.cpp
+++ b/src/Ic/PolytropeIc.cpp
@@ -77,12 +77,12 @@ void PolytropeIc<ndim>::Generate(void)
     int i;                               // Particle counter
     int k;                               // Dimension counter
     FLOAT mp;                            // Mass of individual particle
-    FLOAT z;                             // z-position of newly inserted particle
+    //FLOAT z;                             // z-position of newly inserted particle
 
     // Create local copies of initial conditions parameters
     int Npart      = simparams->intparams["Nhydro"];
     FLOAT eta_eos  = simparams->floatparams["eta_eos"];
-    FLOAT gammaone = simparams->floatparams["gamma_eos"] - (FLOAT) 1.0;
+    //FLOAT gammaone = simparams->floatparams["gamma_eos"] - (FLOAT) 1.0;
     string eos     = simparams->stringparams["gas_eos"];
 
     debug2("[PolytropeIc::Generate]");
@@ -95,6 +95,7 @@ void PolytropeIc<ndim>::Generate(void)
     // Allocate local and main particle memory
     hydro->Nhydro = Npart;
     sim->AllocateParticleMemory();
+    mp = (FLOAT) 0.0;
     //mp = m_box / (FLOAT) Npart;
 
     // Calculate cloud parameters depending on the chosen equation of state

--- a/src/Ic/PolytropeIc.cpp
+++ b/src/Ic/PolytropeIc.cpp
@@ -82,7 +82,6 @@ void PolytropeIc<ndim>::Generate(void)
     // Create local copies of initial conditions parameters
     int Npart      = simparams->intparams["Nhydro"];
     FLOAT eta_eos  = simparams->floatparams["eta_eos"];
-    //FLOAT gammaone = simparams->floatparams["gamma_eos"] - (FLOAT) 1.0;
     string eos     = simparams->stringparams["gas_eos"];
 
     debug2("[PolytropeIc::Generate]");

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -772,22 +772,14 @@ template <int ndim>
 void MeshlessFVSimulation<ndim>::ComputeBlockTimesteps(void)
 {
   int istep;                                 // Aux. variable for changing steps
-  int last_level;                            // Previous timestep level
   int level;                                 // Particle timestep level
-  int level_max_aux;                         // Aux. maximum level variable
   int level_max_nbody = 0;                   // level_max for star particles only
   int level_max_old = level_max;             // Old level_max
   int level_max_hydro = 0;                   // level_max for hydro particles only
   int level_min_hydro = 9999999;             // level_min for hydro particles
-  int level_nbody;                           // local thread var. for N-body level
-  int level_hydro;                           // local thread var. for hydro level
   int nfactor;                               // Increase/decrease factor of n
-  //int nstep;                                 // Particle integer step-size
   DOUBLE dt;                                 // Aux. timestep variable
   DOUBLE dt_min = big_number_dp;             // Minimum timestep
-  //DOUBLE dt_min_aux;                         // Aux. minimum timestep variable
-  //DOUBLE dt_nbody;                           // Aux. minimum N-body timestep
-  //DOUBLE dt_hydro;                           // Aux. minimum hydro timestep
 
   debug2("[MeshlessFVSimulation::ComputeBlockTimesteps]");
   CodeTiming::BlockTimer timer = timing->StartNewTimer("BLOCK_TIMESTEPS");
@@ -804,7 +796,7 @@ void MeshlessFVSimulation<ndim>::ComputeBlockTimesteps(void)
     n = 0;
     timestep = big_number_dp;
 
-#pragma omp parallel default(none) shared(dt_min) private(dt, level) //private(dt,dt_min_aux,dt_nbody,dt_hydro,i)
+#pragma omp parallel default(none) shared(dt_min) private(dt, level)
     {
       // Initialise all timestep and min/max variables
       DOUBLE dt_min_aux = big_number_dp;
@@ -932,15 +924,14 @@ void MeshlessFVSimulation<ndim>::ComputeBlockTimesteps(void)
     level_max_hydro = 0;
 
 
-#pragma omp parallel default(shared) private(dt, level) \
-    shared(dt_min, istep, level_max_hydro, level_max_nbody, level_max_old, nfactor)
+#pragma omp parallel default(shared) private (dt, istep, level, nfactor) \
+shared(dt_min, level_max_hydro, level_max_nbody, level_max_old)
     {
       int last_level;
       int nstep;
       int level_max_aux = 0;
       int level_nbody   = 0;
       int level_hydro   = 0;
-      DOUBLE dt;
       DOUBLE dt_hydro   = big_number_dp;
       DOUBLE dt_nbody   = big_number_dp;
 

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -502,7 +502,6 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
   for (int t = neibmanagerbufflux.size(); t < Nthreads; ++t)
     neibmanagerbufflux.push_back(NeighbourManagerFlux(mfv, simbox));
 
-  //int Nhydro = mfv->Nhydro;
   int Ntot = mfv->Ntot;
   MeshlessFVParticle<ndim> *mfvdata = mfv->GetMeshlessFVParticleArray();
 
@@ -531,7 +530,6 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
     FLOAT (*fluxBuffer)[ndim+2]    = new FLOAT[Ntot][ndim+2];  // ..
     FLOAT (*rdmdtBuffer)[ndim]     = new FLOAT[Ntot][ndim];    // ..
     ParticleType<ndim>* activepart = activepartbuf[ithread];   // ..
-    //ParticleType<ndim>* neibpart   = neibpartbuf[ithread];     // ..
     NeighbourManager<ndim,FluxParticle>& neibmanager = neibmanagerbufflux[ithread];
 
     for (int i=0; i<Ntot; i++) {
@@ -707,7 +705,6 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllGravForces
     FLOAT potperiodic;                           // ..
     int *activelist  = activelistbuf[ithread];   // ..
     ParticleType<ndim>* activepart  = activepartbuf[ithread];   // ..
-    //ParticleType<ndim>* neibpart    = neibpartbuf[ithread];     // ..
     Typemask gravmask = mfv->types.gravmask;
     NeighbourManagerGrav neibmanager = neibmanagerbufgrav[ithread];
     Typemask hydromask ;

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -112,7 +112,7 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllProperties
 
   // Set-up all OMP threads
   //===============================================================================================
-#pragma omp parallel default(none) shared(cactive,celllist,cout,nbody,mfv,mfvdata,Ntot)
+#pragma omp parallel default(none) shared(cactive,celllist,cout,nbody,mfv,mfvdata)
   {
 #if defined _OPENMP
     const int ithread = omp_get_thread_num();
@@ -509,7 +509,7 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
   for (int t = neibmanagerbufflux.size(); t < Nthreads; ++t)
     neibmanagerbufflux.push_back(NeighbourManagerFlux(mfv, simbox));
 
-  int Nhydro = mfv->Nhydro ;
+  //int Nhydro = mfv->Nhydro;
   int Ntot = mfv->Ntot;
   MeshlessFVParticle<ndim> *mfvdata = mfv->GetMeshlessFVParticleArray();
 
@@ -523,7 +523,7 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
 
   // Set-up all OMP threads
   //===============================================================================================
-#pragma omp parallel default(none) shared(cactive,celllist,mfv,mfvdata, Nhydro, Ntot, simbox)
+#pragma omp parallel default(none) shared(cactive,celllist,mfv,mfvdata,Ntot)
   {
 #if defined _OPENMP
     const int ithread = omp_get_thread_num();

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -369,10 +369,8 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGradientMatrices
     int cc;                                        // Aux. cell counter
     int i;                                         // Particle id
     int j;                                         // Aux. particle counter
-    int jj;                                        // Aux. particle counter
     int k;                                         // Dimension counter
     int Nactive;                                   // ..
-    int Nneibmax    = Nneibmaxbuf[ithread];        // ..
     int* activelist = activelistbuf[ithread];      // ..
     int* levelneib  = levelneibbuf[ithread];       // ..
     ParticleType<ndim>* activepart = activepartbuf[ithread];   // ..
@@ -533,16 +531,14 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
     const int ithread = 0;
 #endif
     int i;                                         // Particle id
-    int j;                                         // Aux. particle counter
     int k;                                         // Dimension counter
     int Nactive;                                   // ..
-    int Nneibmax      = Nneibmaxbuf[ithread];      // ..
     int* activelist   = activelistbuf[ithread];    // ..
     FLOAT (*dQBuffer)[ndim+2]      = new FLOAT[Ntot][ndim+2];  // ..
     FLOAT (*fluxBuffer)[ndim+2]    = new FLOAT[Ntot][ndim+2];  // ..
     FLOAT (*rdmdtBuffer)[ndim]     = new FLOAT[Ntot][ndim];    // ..
     ParticleType<ndim>* activepart = activepartbuf[ithread];   // ..
-    ParticleType<ndim>* neibpart   = neibpartbuf[ithread];     // ..
+    //ParticleType<ndim>* neibpart   = neibpartbuf[ithread];     // ..
     NeighbourManager<ndim,FluxParticle>& neibmanager = neibmanagerbufflux[ithread];
 
     for (int i=0; i<Ntot; i++) {
@@ -715,14 +711,10 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllGravForces
     int Nactive;                                 // ..
     FLOAT aperiodic[ndim];                       // ..
     FLOAT draux[ndim];                           // Aux. relative position vector
-    FLOAT drsqd;                                 // Distance squared
-    FLOAT hrangesqdi;                            // Kernel gather extent
-    FLOAT macfactor;                             // Gravity MAC factor
     FLOAT potperiodic;                           // ..
-    FLOAT rp[ndim];                              // ..
     int *activelist  = activelistbuf[ithread];   // ..
     ParticleType<ndim>* activepart  = activepartbuf[ithread];   // ..
-    ParticleType<ndim>* neibpart    = neibpartbuf[ithread];     // ..
+    //ParticleType<ndim>* neibpart    = neibpartbuf[ithread];     // ..
     Typemask gravmask = mfv->types.gravmask;
     NeighbourManagerGrav neibmanager = neibmanagerbufgrav[ithread];
     Typemask hydromask ;
@@ -773,14 +765,14 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateAllGravForces
           const int i = activelist[j];
 
           // Only calculate gravity for active particle types that have self-gravity activated
-          if (mfv->types[activepart[j].ptype].self_gravity){
+          if (mfv->types[activepart[j].ptype].self_gravity) {
 
-		    GravityNeighbourLists<GravParticle> neiblists =
-		        neibmanager.GetParticleNeibGravity(activepart[j],hydromask);
-
+            GravityNeighbourLists<GravParticle> neiblists =
+              neibmanager.GetParticleNeibGravity(activepart[j],hydromask);
 
             // Compute forces with hydro neighbours
             mfv->ComputeSmoothedGravForces(activepart[j], neiblists.neiblist);
+            
             // Compute forces with non-hydro neighbours
             mfv->ComputeSmoothedGravForces(activepart[j], neiblists.smooth_gravlist);
 

--- a/src/Nbody/NbodySimulation.cpp
+++ b/src/Nbody/NbodySimulation.cpp
@@ -568,12 +568,15 @@ void NbodySimulation<ndim>::ComputeBlockTimesteps(void)
 
           // Move up one level (if levels are correctly synchronised) or
           // down several levels if required
-          if (level < last_level && last_level > 1 && n%(2*nstep) == 0)
+          if (level < last_level && last_level > 1 && n%(2*nstep) == 0) {
             nbody->nbodydata[i]->level = last_level - 1;
-          else if (level > last_level)
+          }
+          else if (level > last_level) {
             nbody->nbodydata[i]->level = level;
-          else
+          }
+          else {
             nbody->nbodydata[i]->level = last_level;
+          }
 
           nbody->nbodydata[i]->tlast = t;
           nbody->nbodydata[i]->nlast = n;
@@ -615,42 +618,31 @@ void NbodySimulation<ndim>::ComputeBlockTimesteps(void)
     }
 
 
+    istep = pow(2, level_step - level_max_old + 1);
+
     // Update all timestep variables if we have removed or added any levels
     //---------------------------------------------------------------------------------------------
-    if (level_max != level_max_old) {
-
-      // Increase maximum timestep level if correctly synchronised
-      istep = pow(2,level_step - level_max_old + 1);
-      if (level_max <= level_max_old - 1 && level_max_old > 1 && n%istep == 0)
-        level_max = level_max_old - 1;
-      else if (level_max == level_max_old)
-        level_max = level_max_old;
-
-      // Adjust integer time if levels added or removed
-      if (level_max > level_max_old) {
-        nfactor = pow(2,level_max - level_max_old);
-        n *= nfactor;
-        for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nstep *= nfactor;
-        for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nlast *= nfactor;
-      }
-      else if (level_max < level_max_old) {
-        nfactor = pow(2,level_max_old - level_max);
-        n /= nfactor;
-        for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nlast /= nfactor;
-        for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nstep /= nfactor;
-      }
-
-      // Update values of nstep for both SPH and star particles
-      for (i=0; i<nbody->Nnbody; i++) {
-        if (nbody->nbodydata[i]->nlast == n) nbody->nbodydata[i]->nstep =
-          pow(2,level_step - nbody->nbodydata[i]->level);
-      }
-
-      nresync = pow(2, level_step);
-      timestep = dt_max / (DOUBLE) nresync;
-
+    if (level_max > level_max_old) {
+      nfactor = pow(2, level_max - level_max_old);
+      n *= nfactor;
+      for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nstep *= nfactor;
+      for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nlast *= nfactor;
     }
-    //---------------------------------------------------------------------------------------------
+    else if (level_max <= level_max_old - 1 && level_max_old > 1 && n%istep == 0) {
+      nfactor = pow(2, level_max_old - level_max);
+      n /= nfactor;
+      for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nlast /= nfactor;
+      for (i=0; i<nbody->Nnbody; i++) nbody->nbodydata[i]->nstep /= nfactor;
+    }
+
+    nresync = pow(2, level_step);
+    timestep = dt_max / (DOUBLE) nresync;
+
+    // Update values of nstep for both SPH and star particles
+    for (i=0; i<nbody->Nnbody; i++) {
+      if (nbody->nbodydata[i]->nlast == n) nbody->nbodydata[i]->nstep =
+        pow(2,level_step - nbody->nbodydata[i]->level);
+    }
 
   }
   //===============================================================================================

--- a/src/Tree/HydroTree.cpp
+++ b/src/Tree/HydroTree.cpp
@@ -675,7 +675,7 @@ void HydroTree<ndim,ParticleType>::UpdateTimestepsLimitsFromDistantParticles
 (Hydrodynamics<ndim>* hydro,                     ///<[inout] Pointer to Hydrodynamics object
  const bool only_imported_particles)								///<[in] Wheter we need to loop only over imported particles (relevant only for MPI)
  {
-  int cactive;                          // No. of active cells
+  int cactive = 0;                      // No. of active cells
   vector<TreeCellBase<ndim> > celllist; // List of active tree cells
   ParticleType<ndim>* partdata = static_cast<ParticleType<ndim>* > (hydro->GetParticleArray());
 

--- a/src/Tree/Tree.cpp
+++ b/src/Tree/Tree.cpp
@@ -631,20 +631,16 @@ void Tree<ndim,ParticleType,TreeCell>::ComputeGravityInteractionAndGhostList
 {
   int cc = 0;                          // Cell counter
   FLOAT dr[ndim];                      // Relative position vector
-  FLOAT dr_corr[ndim];                 // Periodic correction vector
   FLOAT rc[ndim];                      // Position of cell
-
-  const GhostNeighbourFinder<ndim> GhostFinder(_domain, cell) ;
-
+  const GhostNeighbourFinder<ndim> GhostFinder(_domain, cell);
   assert(GhostFinder.MaxNumGhosts() == 1) ;
 
   // Make local copies of important cell properties
-  const FLOAT hrangemaxsqd = pow(cell.rmax + kernrange*cell.hmax,2);
-  const FLOAT rmax = cell.rmax;
-  const FLOAT amin = cell.amin;
+  const FLOAT hrangemax = kernrange*cell.hmax;
+  const FLOAT rmax      = cell.rmax;
+  const FLOAT amin      = cell.amin;
   const FLOAT macfactor = cell.macfactor;
   for (int k=0; k<ndim; k++) rc[k] = cell.rcell[k];
-  for (int k=0; k<ndim; k++) dr_corr[k] = 0 ;
 
   // Start with root cell and walk through entire tree
   // Walk through all cells in tree to determine particle and cell interaction lists
@@ -658,8 +654,8 @@ void Tree<ndim,ParticleType,TreeCell>::ComputeGravityInteractionAndGhostList
 
     // Check if bounding spheres overlap with each other (for potential SPH neibs)
     //---------------------------------------------------------------------------------------------
-    if (drsqd <= pow(celldata[cc].rmax + cell.rmax + kernrange*cell.hmax,2) ||
-        drsqd <= pow(cell.rmax + celldata[cc].rmax + kernrange*celldata[cc].hmax,2)) {
+    if (drsqd <= pow(celldata[cc].rmax + rmax + hrangemax, 2) ||
+        drsqd <= pow(rmax + celldata[cc].rmax + kernrange*celldata[cc].hmax,2)) {
 
       // If not a leaf-cell, then open cell to first child cell
       if (celldata[cc].copen != -1) {
@@ -2009,4 +2005,3 @@ template class Tree<3,SM2012SphParticle,BruteForceTreeCell>;
 template class Tree<1,MeshlessFVParticle,BruteForceTreeCell>;
 template class Tree<2,MeshlessFVParticle,BruteForceTreeCell>;
 template class Tree<3,MeshlessFVParticle,BruteForceTreeCell>;
-


### PR DESCRIPTION
Newer version of previous uninitialised variables pull request.  Cherry-picked from old branch onto newer up-to-date branch from master.  In summary includes : 
- Removal of unused variables
- Initialise any uninitialised variables to a sensible default value
- Casting some unsigned ints to ints in conditional statments (N.B. used C-style casts)
- Some code cleaning up, removal of old unused/out-of-date code
- A few small optimisations (by way of using some intermediate const variables)

Also given the code another sweep for newly introduced unused/uninitialised variables.  The only exceptions are the MultipleSourceIonisation.cpp and TreeRay.cpp files, which will be dealt with in a future pull request.  Hopefully this can be merged quickly before it goes out-of-date (again) with the master branch.