### PR TITLE
Added safety check for integral gradients

### DIFF
--- a/src/Headers/GhostNeighbours.hpp
+++ b/src/Headers/GhostNeighbours.hpp
@@ -421,7 +421,7 @@ private:
 
 		// Do reflections on the left edge
 		if (_mirror_bound[k][0]){
-		  FLOAT x  = 2*_domain.min[k] - ngbs[0].r[k];
+		  FLOAT x  = 2*_domain.min[k] - real_particle.r[k];
 		  FLOAT dx = x - _cell.min[k] ;
 		  if (dx*dx < h2 || x > _hbox.min[k]){
 			for (int n=0; n < Nghost; n++){
@@ -434,7 +434,7 @@ private:
 		}
 		// Do reflections on the right edge
 		if (_mirror_bound[k][1]){
-		  FLOAT x  = 2*_domain.max[k] - ngbs[0].r[k];
+		  FLOAT x  = 2*_domain.max[k] - real_particle.r[k];
 		  FLOAT dx = x - _cell.max[k];
 		  if (dx*dx < h2 || x < _hbox.max[k]){
 			for (int n=0; n < Nghost; n++){

--- a/src/Headers/InlineFuncs.h
+++ b/src/Headers/InlineFuncs.h
@@ -576,8 +576,8 @@ inline void __matrixInverter<2>::invert(const FLOAT A[2][2], FLOAT B[2][2]) {
 template<>
 inline void __matrixInverter<3>::invert(const FLOAT A[3][3], FLOAT B[3][3]) {
   const FLOAT invdet = (FLOAT) 1.0/(A[0][0]*(A[1][1]*A[2][2] - A[2][1]*A[1][2]) -
-                                        A[0][1]*(A[1][0]*A[2][2] - A[1][2]*A[2][0]) +
-                                        A[0][2]*(A[1][0]*A[2][1] - A[1][1]*A[2][0]));
+                                    A[0][1]*(A[1][0]*A[2][2] - A[1][2]*A[2][0]) +
+                                    A[0][2]*(A[1][0]*A[2][1] - A[1][1]*A[2][0]));
 
       B[0][0] = (A[1][1]*A[2][2] - A[2][1]*A[1][2])*invdet;
       B[0][1] = (A[0][2]*A[2][1] - A[0][1]*A[2][2])*invdet;

--- a/src/Headers/Particle.h
+++ b/src/Headers/Particle.h
@@ -48,7 +48,7 @@ enum flags {
 	potmin = 1 << 2,
 
 	update_density = 1 << 3, // For meshless
-
+	bad_gradients = 1 << 5,  // For meshless
 
 	x_periodic_lhs = 1 << 7,
 	y_periodic_lhs = 1 << 8,

--- a/src/MeshlessFV/MfvCommon.cpp
+++ b/src/MeshlessFV/MfvCommon.cpp
@@ -332,7 +332,8 @@ void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeGradients
     // Compute SPH (corrected) gradients instead
     part.flags.set_flag(bad_gradients);
 
-    cout << "Bad gradients:\n"
+
+    cout << "Bad integral gradient, using SPH gradients:\n"
          << "\tiorig: " << part.iorig << ", ||E||, ||E^{-1}||: " << modE << " " << modB
          << ", N_cond^2: " << sqd_condition_number << "\n";
 
@@ -351,7 +352,7 @@ void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeGradients
 
       for (var=0; var<nvar; var++)
         for (k=0; k<ndim; k++) {
-          part.grad[var][k] += (draux[k]/dr)*(neibpart[j].Wprim[var] - part.Wprim[var])*w ;
+          part.grad[var][k] -= (neibpart[j].Wprim[var] - part.Wprim[var])*(draux[k]/dr) * w ;
         }
     }
   }

--- a/src/MeshlessFV/MfvCommon.cpp
+++ b/src/MeshlessFV/MfvCommon.cpp
@@ -309,10 +309,50 @@ void MfvCommon<ndim, kernelclass,SlopeLimiter>::ComputeGradients
   // Invert the matrix (depending on dimensionality)
   InvertMatrix<ndim>(E,part.B) ;
 
-  // Complete the calculation of the gradients:
-  for (var=0; var<nvar; var++) {
-    for (k=0; k<ndim; k++) {
-      part.grad[var][k] = DotProduct(part.B[k], grad_tmp[var], ndim) ;
+  // Check the accuracy of the integral gradients (using the square of the condition number)
+  double modE(0), modB(0) ;
+  for (int i=0; i<ndim; i++)
+    for (int j=0; j<ndim; j++){
+      modE +=      E[i][j]*     E[i][j];
+      modB += part.B[i][j]*part.B[i][j];
+    }
+  double sqd_condition_number = modE*modB / (ndim*ndim) ;
+
+  if (sqd_condition_number < 1e4) {
+    part.flags.unset_flag(bad_gradients);
+
+    // Complete the calculation of the gradients:
+    for (var=0; var<nvar; var++) {
+      for (k=0; k<ndim; k++) {
+        part.grad[var][k] = DotProduct(part.B[k], grad_tmp[var], ndim) ;
+      }
+    }
+  }
+  else {
+    // Compute SPH (corrected) gradients instead
+    part.flags.set_flag(bad_gradients);
+
+    cout << "Bad gradients:\n"
+         << "\tiorig: " << part.iorig << ", ||E||, ||E^{-1}||: " << modE << " " << modB
+         << ", N_cond^2: " << sqd_condition_number << "\n";
+
+    for (var=0; var<nvar; var++)
+      for (k=0; k<ndim; k++)
+        part.grad[var][k] = 0;
+
+    for (int j=0; j<Nneib; j++) {
+      for (k=0; k<ndim; k++) draux[k] = neibpart[j].r[k] - part.r[k];
+      drsqd = DotProduct(draux, draux, ndim);
+      double dr = sqrt(drsqd);
+
+      if (dr == 0) continue ;
+
+      double w = (part.hfactor/part.ndens)*kern.w1(dr/part.h);
+
+      for (var=0; var<nvar; var++)
+        for (k=0; k<ndim; k++) {
+          part.grad[var][k] += (draux[k]/dr)*(neibpart[j].Wprim[var] - part.Wprim[var])*w ;
+        }
     }
   }
 

--- a/src/MeshlessFV/MfvMuscl.cpp
+++ b/src/MeshlessFV/MfvMuscl.cpp
@@ -120,8 +120,8 @@ void MfvMuscl<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
     }
     else {
       double dr = sqrt(drsqd) + small_number ;
-      double w = part.hfactor*volume_i * kern.w1(dr/invh_i);
-      for (k=0; k<ndim; k++)  psitildaj[k] = (draux[k]/dr) * w;
+      double w = part.hfactor*volume_i * kern.w1(dr*invh_i);
+      for (k=0; k<ndim; k++)  psitildaj[k] = - (draux[k]/dr) * w;
     }
 
     if (not neibpart[j].flags.check_flag(bad_gradients)) {
@@ -134,9 +134,8 @@ void MfvMuscl<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
     }
     else {
       double dr = sqrt(drsqd) + small_number ;
-      double w = neibpart[j].hfactor*volume_j * kern.w1(dr/invh_j);
-      for (int kk=0; kk<ndim; kk++)
-        psitildai[k] = - (draux[k]/dr) * w;
+      double w = neibpart[j].hfactor*volume_j * kern.w1(dr*invh_j);
+      for (k=0; k<ndim; k++) psitildai[k] = + (draux[k]/dr) * w;
     }
 
     // Compute the face area

--- a/src/MeshlessFV/MfvMuscl.cpp
+++ b/src/MeshlessFV/MfvMuscl.cpp
@@ -109,19 +109,39 @@ void MfvMuscl<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
     for (k=0; k<ndim; k++) draux[k] = neibpart[j].r[k] - part.r[k];
     drsqd = DotProduct(draux, draux, ndim);
 
+    // Compute psi-tilda values using integral / sph gradients.
+    if (not part.flags.check_flag(bad_gradients)) {
+      for (k=0; k<ndim; k++) {
+        psitildaj[k] = 0;
+        for (int kk=0; kk<ndim; kk++)
+          psitildaj[k] += part.B[k][kk]*draux[kk]*part.hfactor*
+              kern.w0_s2(drsqd*invh_i*invh_i)*volume_i;
+      }
+    }
+    else {
+      double dr = sqrt(drsqd) + small_number ;
+      double w = part.hfactor*volume_i * kern.w1(dr/invh_i);
+      for (k=0; k<ndim; k++)  psitildaj[k] = (draux[k]/dr) * w;
+    }
 
-    // Calculate psitilda values
-    for (k=0; k<ndim; k++) {
+    if (not neibpart[j].flags.check_flag(bad_gradients)) {
+      for (k=0; k<ndim; k++) {
       psitildai[k] = 0;
-      psitildaj[k] = 0;
-      for (int kk=0; kk<ndim; kk++) {
+      for (int kk=0; kk<ndim; kk++)
         psitildai[k] -= neibpart[j].B[k][kk]*draux[kk]*neibpart[j].hfactor*
           kern.w0_s2(drsqd*invh_j*invh_j)*volume_j;
-        psitildaj[k] += part.B[k][kk]*draux[kk]*part.hfactor*
-          kern.w0_s2(drsqd*invh_i*invh_i)*volume_i;
       }
-      Aij[k] = volume_i*psitildaj[k] - volume_j*psitildai[k];
     }
+    else {
+      double dr = sqrt(drsqd) + small_number ;
+      double w = neibpart[j].hfactor*volume_j * kern.w1(dr/invh_j);
+      for (int kk=0; kk<ndim; kk++)
+        psitildai[k] = - (draux[k]/dr) * w;
+    }
+
+    // Compute the face area
+    for (k=0; k<ndim; k++)
+      Aij[k] = volume_i*psitildaj[k] - volume_j*psitildai[k];
 
     FLOAT Amag = sqrt(DotProduct(Aij, Aij, ndim) + small_number);
     for (k=0; k<ndim; k++) Aunit[k] = Aij[k] / Amag;

--- a/src/MeshlessFV/MfvRungeKutta.cpp
+++ b/src/MeshlessFV/MfvRungeKutta.cpp
@@ -102,18 +102,38 @@ void MfvRungeKutta<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
     invdrmagaux = 1.0/sqrt(drsqd + small_number);
     for (k=0; k<ndim; k++) dr_unit[k] = draux[k]*invdrmagaux;
 
-    // Calculate psitilda values
-    for (k=0; k<ndim; k++) {
-      psitildai[k] = (FLOAT) 0.0;
-      psitildaj[k] = (FLOAT) 0.0;
-      for (int kk=0; kk<ndim; kk++) {
-        psitildai[k] += neibpart[j].B[k][kk]*draux[kk]*neibpart[j].hfactor*
-            kern.w0_s2(drsqd*invh_j*invh_j)*volume_j;
-        psitildaj[k] -= part.B[k][kk]*draux[kk]*part.hfactor*
-            kern.w0_s2(drsqd*invh_i*invh_i)*volume_i;
+    // Compute psi-tilda values using integral / sph gradients.
+    if (not part.flags.check_flag(bad_gradients)) {
+      for (k=0; k<ndim; k++) {
+        psitildaj[k] = 0;
+        for (int kk=0; kk<ndim; kk++)
+          psitildaj[k] += part.B[k][kk]*draux[kk]*part.hfactor*
+              kern.w0_s2(drsqd*invh_i*invh_i)*volume_i;
       }
-      Aij[k] = volume_i*psitildaj[k] - volume_j*psitildai[k];
     }
+    else {
+      double dr = sqrt(drsqd) + small_number ;
+      double w = part.hfactor*volume_i * kern.w1(dr*invh_i);
+      for (k=0; k<ndim; k++)  psitildaj[k] = - (draux[k]/dr) * w;
+    }
+
+    if (not neibpart[j].flags.check_flag(bad_gradients)) {
+      for (k=0; k<ndim; k++) {
+      psitildai[k] = 0;
+      for (int kk=0; kk<ndim; kk++)
+        psitildai[k] -= neibpart[j].B[k][kk]*draux[kk]*neibpart[j].hfactor*
+          kern.w0_s2(drsqd*invh_j*invh_j)*volume_j;
+      }
+    }
+    else {
+      double dr = sqrt(drsqd) + small_number ;
+      double w = neibpart[j].hfactor*volume_j * kern.w1(dr*invh_j);
+      for (k=0; k<ndim; k++) psitildai[k] = + (draux[k]/dr) * w;
+    }
+
+    // Compute the face area
+    for (k=0; k<ndim; k++)
+      Aij[k] = volume_i*psitildaj[k] - volume_j*psitildai[k];
 
     // Calculate position and velocity of the face
     if (staticParticles) {


### PR DESCRIPTION
I noticed some crashes in the Boss-bodenheimer due to poor gradient estimation. Hopkins points out that this can occur in his paper, and proposes switching back to standard SPH gradients. 

This branch implements a similar fix, using the 'constant exact' SPH gradients. The constant exact gradients are the best choice for fall back for two reasons: 1) They are the most accurate estimate that does not require a matrix inversion, and 2) they allow for a definition of the face areas (derivative of volumes) that is consistent with the normal meshless flux calculation.