### PR TITLE
Fixed python call to Riemann solver with isotheraml eos

### DIFF
--- a/analysis/analytical.py
+++ b/analysis/analytical.py
@@ -260,6 +260,11 @@ class shocktube (AnalyticalSolution):
         self.iMAX   = 16384
         if sim.simparams.stringparams["gas_eos"] == "isothermal":
             self.gamma = 1.0 + 1e-5
+
+            cs2 = simfloatparams['temp0'] / simfloatparams['mu_bar']
+
+            self.PinL   = self.RHOinL * cs2
+            self.PinR   = self.RHOinR * cs2
         else:
             self.gamma = simfloatparams["gamma_eos"]
 


### PR DESCRIPTION
This pull request fixes the analytical solution for shock tube problems that use an iosthermal eos.

The problem was the pressure being passed to the riemann solver was not consistent with the ones used in the simulation.