### PR TITLE
Corrected writing of file format with dust when sinks are present for…

### DIFF
--- a/src/Common/SimulationIO.hpp
+++ b/src/Common/SimulationIO.hpp
@@ -1761,8 +1761,8 @@ bool Simulation<ndim>::WriteSerenUnformSnapshotFile(string filename)
   types[2].ptype = cdm_type ;
   types[3].ptype = dust_type;
 
-  for (int i=0; n<hydro->Nhydro; i++) {
-    Particle<ndim>& part = hydro->GetParticlePointer(i);
+  for (int i=0; i<hydro->Nhydro; i++) {
+    const Particle<ndim>& part = hydro->GetParticlePointer(i);
     if (part.flags.is_dead()) continue;
     switch (part.ptype) {
       case icm_type:
@@ -1774,7 +1774,7 @@ bool Simulation<ndim>::WriteSerenUnformSnapshotFile(string filename)
       case dust_type:
         types[3].Ntot_type++; break;
       default:
-        ExceptionHandler::getIstance().raise("SerenUnformReader: Type not recognised");
+        ExceptionHandler::getIstance().raise("SerenUnformReader: Type not recognised : " + part.ptype);
     }
   }
 

--- a/src/Common/SimulationIO.hpp
+++ b/src/Common/SimulationIO.hpp
@@ -1699,7 +1699,7 @@ bool Simulation<ndim>::WriteSerenUnformSnapshotFile(string filename)
     typedata[ndata][4] = 0; ndata++;
 
     data_id[ndata] = "r";
-    typedata[ndata][0] = ndim; typedata[ndata][1] = 1;problem
+    typedata[ndata][0] = ndim; typedata[ndata][1] = 1;
     typedata[ndata][2] = Ntot_hydro; typedata[ndata][3] = 4;
     typedata[ndata][4] = 1; ndata++;
 

--- a/src/GradhSph/GradhSphTree.cpp
+++ b/src/GradhSph/GradhSphTree.cpp
@@ -221,7 +221,7 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphProperties
           for (jj=0; jj<Nneib; jj++) {
 
             // Only include particles of appropriate types in density calculation
-            if (!sph->types[activepart[j].ptype].hmask[ptype[jj]]) continue ;
+            if (!sph->types[activepart[j].ptype].hmask[ptype[jj]]) continue;
 
             for (k=0; k<ndim; k++) draux[k] = r[ndim*jj + k] - rp[k];
             drsqdaux = DotProduct(draux,draux,ndim) + small_number;
@@ -385,8 +385,8 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphHydroForces
               neibmanager.GetParticleNeib(activepart[j],hydromask,do_pair_once);
 
 #if defined(VERIFY_ALL)
-          neibmanager.VerifyNeighbourList(i, sph->Nhydro, sphdata, "all");
-          neibmanager.VerifyReducedNeighbourList(i, neiblist, sph->Nhydro, sphdata, "all");
+          neibmanager.VerifyNeighbourList(activelist[j], sph->Nhydro, sphdata, "all");
+          neibmanager.VerifyReducedNeighbourList(activelist[j], neiblist, sph->Nhydro, sphdata, "all");
 #endif
 
           // Compute all neighbour contributions to hydro forces
@@ -584,9 +584,7 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
             int Ntotneib = neibmanager.GetNumAllNeib();
 
             for (int jj=0; jj< Ntotneib; jj++) {
-
-            if (!gravmask[neibmanager[jj].ptype]) continue;
-
+              if (!gravmask[neibmanager[jj].ptype]) continue;
               FLOAT draux[ndim];
               for (int k=0; k<ndim; k++) draux[k] = neibmanager[jj].r[k] - activepart[j].r[k];
               ewald->CalculatePeriodicCorrection(neibmanager[jj].m, draux, aperiodic, potperiodic);
@@ -622,11 +620,11 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
 
       // Compute all star forces for active particles
       if (nbody->Nnbody > 0) {
-		  for (int j=0; j<Nactive; j++) {
-			  if (activelist[j] < sph->Nhydro) {
-				  sph->ComputeStarGravForces(nbody->Nnbody, nbody->nbodydata, activepart[j]);
-			  }
-		  }
+        for (int j=0; j<Nactive; j++) {
+          if (activelist[j] < sph->Nhydro) {
+            sph->ComputeStarGravForces(nbody->Nnbody, nbody->nbodydata, activepart[j]);
+          }
+        }
       }
 
       // Add all active particles contributions to main array
@@ -644,11 +642,11 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
       // Update levelneib for neighbours
       const int Nneib_cell = neibmanager.GetNumAllNeib();
       for (int jj=0; jj<Nneib_cell; jj++) {
-    	std::pair<int,HydroParticle*> neighbour=neibmanager.GetNeibI(jj);
-    	const int i=neighbour.first;
-    	HydroParticle& neibpart=*(neighbour.second);
-    	levelneib[i]=max(levelneib[i],neibpart.levelneib);
-       }
+        std::pair<int,HydroParticle*> neighbour=neibmanager.GetNeibI(jj);
+        const int i=neighbour.first;
+        HydroParticle& neibpart=*(neighbour.second);
+        levelneib[i]=max(levelneib[i],neibpart.levelneib);
+      }
 
     }
     //=============================================================================================

--- a/src/Headers/NeighbourManager.h
+++ b/src/Headers/NeighbourManager.h
@@ -608,6 +608,7 @@ public:
          for (int k=0; k<ndim; k++) dr[k] = partdata[j].r[k] - partdata[i].r[k];
          GhostFinder.NearestPeriodicVector(dr);
          drsqd = DotProduct(dr,dr,ndim);
+         if (partdata[j].flags.is_dead()) continue;
          if (drsqd <= partdata[i].hrangesqd) truengb.push_back(j);
        }
      }
@@ -616,6 +617,7 @@ public:
          for (int k=0; k<ndim; k++) dr[k] = partdata[j].r[k] - partdata[i].r[k];
          GhostFinder.NearestPeriodicVector(dr);
          drsqd = DotProduct(dr,dr,ndim);
+         if (partdata[j].flags.is_dead()) continue;
          if (drsqd <= partdata[i].hrangesqd ||
              drsqd <= partdata[j].hrangesqd) truengb.push_back(j);
        }

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -839,12 +839,7 @@ void SphSimulation<ndim>::MainLoop(void)
       nbody->UpdateStellarProperties();
       if (extra_sink_output) WriteExtraSinkOutput();
     }
-    // If we will output a snapshot (regular or for restarts), then delete all accreted particles
-    /*if ((t >= tsnapnext && sinks->Nsink > 0) || n == nresync || kill_simulation ||
-         timing->RunningTime()  > (FLOAT) 0.99*tmax_wallclock) {
-      sph->DeleteDeadParticles();
-      rebuild_tree = true;
-    }*/
+
   }
 
 

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -840,11 +840,11 @@ void SphSimulation<ndim>::MainLoop(void)
       if (extra_sink_output) WriteExtraSinkOutput();
     }
     // If we will output a snapshot (regular or for restarts), then delete all accreted particles
-    if ((t >= tsnapnext && sinks->Nsink > 0) || n == nresync || kill_simulation ||
+    /*if ((t >= tsnapnext && sinks->Nsink > 0) || n == nresync || kill_simulation ||
          timing->RunningTime()  > (FLOAT) 0.99*tmax_wallclock) {
       sph->DeleteDeadParticles();
       rebuild_tree = true;
-    }
+    }*/
   }
 
 

--- a/src/MeshlessFV/MeshlessFVTree.cpp
+++ b/src/MeshlessFV/MeshlessFVTree.cpp
@@ -578,7 +578,7 @@ void MeshlessFVTree<ndim,ParticleType>::UpdateGodunovFluxes
             neibmanager.GetParticleNeib(activepart[j],hydromask,do_pair_once);
 
 #if defined(VERIFY_ALL)
-        neibmanager.VerifyNeighbourList(i, Nhydro, mfvdata, "all");
+        neibmanager.VerifyNeighbourList(i, mfv->Nhydro, mfvdata, "all");
 #endif
 
         // Compute all neighbour contributions to hydro fluxes

--- a/src/Tree/HydroTree.cpp
+++ b/src/Tree/HydroTree.cpp
@@ -1922,6 +1922,7 @@ void HydroTree<ndim,ParticleType>::CheckValidNeighbourList
     for (j=0; j<Ntot; j++) {
       for (k=0; k<ndim; k++) dr[k] = partdata[j].r[k] - partdata[i].r[k];
       drsqd = DotProduct(dr,dr,ndim);
+      if (partdata[j].flags.is_dead()) continue;
       if (drsqd <= kernrangesqd*partdata[i].h*partdata[i].h) trueneiblist[Ntrueneib++] = j;
     }
   }
@@ -1929,6 +1930,7 @@ void HydroTree<ndim,ParticleType>::CheckValidNeighbourList
     for (j=0; j<Ntot; j++) {
       for (k=0; k<ndim; k++) dr[k] = partdata[j].r[k] - partdata[i].r[k];
       drsqd = DotProduct(dr,dr,ndim);
+      if (partdata[j].flags.is_dead()) continue;
       if (drsqd < kernrangesqd*partdata[i].h*partdata[i].h ||
           drsqd < kernrangesqd*partdata[j].h*partdata[j].h) trueneiblist[Ntrueneib++] = j;
     }

--- a/src/Tree/HydroTree.cpp
+++ b/src/Tree/HydroTree.cpp
@@ -1018,7 +1018,7 @@ void HydroTree<ndim,ParticleType>::UpdateHydroExportList
     //=============================================================================================
 
 #ifdef VERIFY_ALL
-    PrintArray("Ncellexport : ",Nmpi,Ncellexport);
+    //PrintArray("Ncellexport : ",Nmpi,Ncellexport);
     PrintArray("Npartexport : ",Nmpi,Npartexport);
 #endif
 


### PR DESCRIPTION
… su and sf formats

The particles are now always sorted by type in the su/sf formats. I haven't changed the column format since it isn't supporring different particle types anyway. 