### PR TITLE
RadWS Fix

### DIFF
--- a/src/GradhSph/GradhSph.cpp
+++ b/src/GradhSph/GradhSph.cpp
@@ -430,7 +430,7 @@ void GradhSph<ndim, kernelclass>::ComputeSphHydroForces
       else if (acond == price2008) {
         parti.dudt += (FLOAT) 0.5*neibpart[j].m*(parti.u - neibpart[j].u)*
           winvrho*(invrho_i + invrho_j)*
-          sqrt(fabs(eos->Pressure(parti) - eos->Pressure(neibpart[j])));
+          sqrt(fabs(eos->Pressure(parti) - eos->HydroForcesPressure(neibpart[j])));
       }
 
     }
@@ -543,7 +543,7 @@ void GradhSph<ndim, kernelclass>::ComputeSphHydroGravForces
       else if (acond == price2008) {
         parti.dudt += (FLOAT) 0.5*neibpart[j].m*(parti.u - neibpart[j].u)*
           winvrho*(invrho_i + invrho_j)*
-          sqrt(fabs(eos->Pressure(parti) - eos->Pressure(neibpart[j])));
+          sqrt(fabs(eos->Pressure(parti) - eos->HydroForcesPressure(neibpart[j])));
       }
 
     }

--- a/src/GradhSph/GradhSphTree.cpp
+++ b/src/GradhSph/GradhSphTree.cpp
@@ -592,7 +592,11 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
         ComputeFastQuadrupoleForces(Nactive, Ngravcell, gravcell, cell, activepart, sph->types);
       }
 
-
+      // Set gpot_hydro (RadWS) before sink contribution
+      // TODO (MERCER): Add gpot contribution from sinks that form
+      for (int j=0; j<Nactive; j++) {
+        activepart[j].gpot_hydro = activepart[j].gpot;
+      }
 
       // Compute all star forces for active particles
       if (nbody->Nnbody > 0) {
@@ -610,6 +614,7 @@ void GradhSphTree<ndim,ParticleType>::UpdateAllSphForces
         for (int k=0; k<ndim; k++) sphdata[i].a[k]     += activepart[j].atree[k];
         for (int k=0; k<ndim; k++) sphdata[i].atree[k] += activepart[j].atree[k];
         sphdata[i].gpot  += activepart[j].gpot;
+        sphdata[i].gpot_hydro += activepart[j].gpot_hydro;
         sphdata[i].dudt  += activepart[j].dudt;
         sphdata[i].div_v += activepart[j].div_v;
         levelneib[i]      = max(levelneib[i],activepart[j].levelneib);

--- a/src/Headers/EOS.h
+++ b/src/Headers/EOS.h
@@ -85,7 +85,7 @@ class EOS
 
   virtual ~EOS() {};
 
-  template <class ParticleType> FLOAT Pressure(const ParticleType& part) {return gammam1*part.rho*part.u;} ;
+  template <class ParticleType> FLOAT Pressure(const ParticleType& part) { return (part.gamma - 1.0)*part.rho*part.u;} ;
   virtual FLOAT EntropicFunction(Particle<ndim> &) = 0;
   virtual FLOAT SoundSpeed(Particle<ndim> &) = 0;
   virtual FLOAT Temperature(Particle<ndim> &) = 0;
@@ -426,14 +426,13 @@ class MCRadiationEOS: public EOS<ndim>
 template <int ndim>
 class Radws : public EOS<ndim>
 {
-  using EOS<ndim>::gamma;
-  using EOS<ndim>::gammam1;
 
  public:
 
   Radws(Parameters*, SimUnits *);
   ~Radws();
 
+  FLOAT Pressure(Particle<ndim> &);
   FLOAT EntropicFunction(Particle<ndim> &);
   FLOAT SoundSpeed(Particle<ndim> &);
   FLOAT Temperature(Particle<ndim> &);

--- a/src/Headers/EOS.h
+++ b/src/Headers/EOS.h
@@ -85,7 +85,8 @@ class EOS
 
   virtual ~EOS() {};
 
-  template <class ParticleType> FLOAT Pressure(const ParticleType& part) { return (part.gamma - 1.0)*part.rho*part.u;} ;
+  template<class ParticleType> FLOAT HydroForcesPressure(const ParticleType &part) { return gammam1*part.rho*part.u; }
+  virtual FLOAT Pressure(Particle<ndim> &part) { return gammam1*part.rho*part.u; }
   virtual FLOAT EntropicFunction(Particle<ndim> &) = 0;
   virtual FLOAT SoundSpeed(Particle<ndim> &) = 0;
   virtual FLOAT Temperature(Particle<ndim> &) = 0;

--- a/src/Headers/EnergyEquation.h
+++ b/src/Headers/EnergyEquation.h
@@ -80,9 +80,9 @@ class EnergyRadws : public EnergyEquation<ndim>
   void EnergyCorrectionTerms(const int, const FLOAT, const FLOAT, Hydrodynamics<ndim> *) {};
   void EndTimestep(const int, const FLOAT, const FLOAT, Hydrodynamics<ndim> *);
   void EnergyFindEqui(const FLOAT, const FLOAT, const FLOAT, const FLOAT,
-                      const FLOAT, FLOAT &, FLOAT &, FLOAT &);
+                      const FLOAT, FLOAT &, FLOAT &);
   void EnergyFindEquiTemp(const int, const FLOAT, const FLOAT, const FLOAT,
-                          const FLOAT, FLOAT &, FLOAT &);
+                          const FLOAT, FLOAT &);
   DOUBLE Timestep(Particle<ndim> &) {return big_number_dp;}
 
   FLOAT ebalance(const FLOAT, const FLOAT, const FLOAT, const FLOAT, const FLOAT, const FLOAT);

--- a/src/Headers/EnergyEquation.h
+++ b/src/Headers/EnergyEquation.h
@@ -91,6 +91,7 @@ class EnergyRadws : public EnergyEquation<ndim>
   void GetKappa(int, int, FLOAT, FLOAT, FLOAT &, FLOAT &, FLOAT &);
   FLOAT GetEnergy(const int, const int, const FLOAT, const FLOAT);
   FLOAT GetMuBar(const int, const int, const FLOAT, const FLOAT);
+  FLOAT GetTemp(Particle<ndim> &part);
 
 
   //-----------------------------------------------------------------------------------------------
@@ -102,6 +103,7 @@ class EnergyRadws : public EnergyEquation<ndim>
   FLOAT *eos_temp ;
   FLOAT **eos_energy;
   FLOAT **eos_mu;
+  FLOAT **eos_gamma;
   FLOAT **kappa_table;
   FLOAT **kappar_table;
   FLOAT **kappap_table;

--- a/src/Headers/Particle.h
+++ b/src/Headers/Particle.h
@@ -212,7 +212,7 @@ struct Particle
     mu_bar    = (FLOAT) 1.0;
     ueq       = (FLOAT) 0.0;
     dt_therm  = (FLOAT) 0.0;
-    gamma    = (FLOAT) 1.66;
+    gamma    = (FLOAT) 1.0;
     vsig_max  = (FLOAT) 0.0;
   }
 

--- a/src/Headers/Particle.h
+++ b/src/Headers/Particle.h
@@ -160,6 +160,7 @@ struct Particle
   FLOAT dudt0;                      ///< dudt at beginning of step
   FLOAT dudt;                       ///< Compressional heating rate
   FLOAT gpot;                       ///< Gravitational potential
+  FLOAT gpot_hydro;                 ///< Gravitaitonal potential w/o star
   DOUBLE dt;                        ///< Particle timestep
   DOUBLE dt_next;                   ///< Next time-step timestep
   DOUBLE tlast;                     ///< Time at beginning of current step
@@ -168,6 +169,7 @@ struct Particle
   FLOAT mu_bar;                     ///< mean molecular weight
   FLOAT ueq;                        ///< equilibrium internal energy
   FLOAT dt_therm;                   ///< thermalization time scale
+  FLOAT gamma;                      ///< ratio of heat capacities
   FLOAT vsig_max;                   ///< Maximum signal velocity.
   FLOAT rad_pres[ndim];             ///< Acceleration from radiation pressure cmscott
   int ionstate;                     ///< States current ionisation state of the particle
@@ -201,12 +203,16 @@ struct Particle
     dudt      = (FLOAT) 0.0;
     dudt0     = (FLOAT) 0.0;
     gpot      = (FLOAT) 0.0;
+    gpot_hydro = (FLOAT) 0.0;
     dt        = (DOUBLE) 0.0;
     dt_next   = (DOUBLE) 0.0;
     tlast     = (DOUBLE) 0.0;
     ionfrac   = (FLOAT) 0.999;
     Xion      = (FLOAT) 0.999;
     mu_bar    = (FLOAT) 1.0;
+    ueq       = (FLOAT) 0.0;
+    dt_therm  = (FLOAT) 0.0;
+    gamma    = (FLOAT) 1.66;
     vsig_max  = (FLOAT) 0.0;
   }
 
@@ -351,6 +357,7 @@ struct GradhSphParticle : public SphParticle<ndim>
 	  FLOAT u;
 	  FLOAT alpha;
       FLOAT zeta;
+    FLOAT gamma;
 	  static const int NDIM=ndim;
 
   };

--- a/src/Hydrodynamics/EnergyRadws.cpp
+++ b/src/Hydrodynamics/EnergyRadws.cpp
@@ -252,10 +252,8 @@ void EnergyRadws<ndim,ParticleType>::EndTimestep
 
       temp = GetTemp(part);
 
-      // Get new ueq and dt_therm
-      // cout << part.gpot << "\t" << part.gpot_hydro << "\n";
-      EnergyFindEqui(part.rho, temp, part.gpot_hydro, part.u, part.dudt,
-                     part.ueq, part.dt_therm, part.mu_bar);
+      EnergyFindEqui(part.rho, temp, part.gpot, part.u, part.dudt,
+                     part.ueq, part.dt_therm);
 
 
       part.u0 = part.u;
@@ -282,8 +280,7 @@ void EnergyRadws<ndim,ParticleType>:: EnergyFindEqui
   const FLOAT u,                               ///< [in] ..
   const FLOAT dudt,                            ///< [in] ..
   FLOAT &ueq_p,                                ///< [out] ..
-  FLOAT &dt_thermal,                           ///< [out] ..
-  FLOAT &mu_bar_equi)                          ///< [out] ..
+  FLOAT &dt_thermal)                           ///< [out] ..
 {
   const FLOAT fcolumn2 = 0.010816;             // ..
   const FLOAT col2     = fcolumn2*gpot*rho;    // ..
@@ -309,7 +306,7 @@ void EnergyRadws<ndim,ParticleType>:: EnergyFindEqui
   dudt_rad = ebalance((FLOAT) 0.0, temp_ambient, temp, kappa, kappap, col2);
 
   // Calculate equilibrium temperature using implicit scheme described in Stamatellos et al. (2007)
-  EnergyFindEquiTemp(idens, rho, temp, col2, dudt, Tequi, mu_bar_equi);
+  EnergyFindEquiTemp(idens, rho, temp, col2, dudt, Tequi);
   assert(Tequi >= temp_ambient);
 
   // Get ueq_p and dudt_eq from Tequi
@@ -339,8 +336,7 @@ void EnergyRadws<ndim,ParticleType>::EnergyFindEquiTemp
   const FLOAT temp,                        ///< ..
   const FLOAT col2,                        ///< ..
   const FLOAT dudt,                        ///< ..
-  FLOAT &Tequi,                            ///< ..
-  FLOAT &mu_bar_equi)                      ///< ..
+  FLOAT &Tequi)
 {
   int itemp;
   int itemplow, itemphigh;
@@ -352,7 +348,6 @@ void EnergyRadws<ndim,ParticleType>::EnergyFindEquiTemp
   FLOAT kappaLow, kappaHigh, kappapLow, kappapHigh;
   FLOAT logtemp, logrho;
   FLOAT Tlow, Thigh, Tlow_log, Thigh_log, Tequi_log;
-  FLOAT mu_bar_high, mu_bar_low;
   FLOAT dtemp;
 
   logrho = log10(rho);

--- a/src/Hydrodynamics/EnergyRadws.cpp
+++ b/src/Hydrodynamics/EnergyRadws.cpp
@@ -58,7 +58,7 @@ EnergyRadws<ndim,ParticleType>::EnergyRadws
 {
   int i, j, l;
   // int ndens, ntemp; defined in EnergyEquation
-  DOUBLE eos_dens_, eos_temp_, eos_energy_, eos_mu_, kappa_, kappar_, kappap_;
+  DOUBLE eos_dens_, eos_temp_, eos_energy_, eos_mu_, kappa_, kappar_, kappap_, eos_gamma_;
   DOUBLE num, denom, tempunit;
   string line;
 
@@ -69,52 +69,35 @@ EnergyRadws<ndim,ParticleType>::EnergyRadws
   denom     = simunits->E.outscale * simunits->E.outSI;
   tempunit  = simunits->temp.outscale * simunits->temp.outSI;
   rad_const = stefboltz*(num*pow(tempunit,4.0))/denom;
-
   temp_ambient = temp_ambient_ / tempunit;
-  cout << "Temp_ambient : " << temp_ambient << endl;
-  cout << "units     : " << num << " "<< denom << " " << tempunit << endl;
-  cout << "u_unit    : " << simunits->u.outscale * simunits->u.outcgs << endl;
-  cout << "time_unit : " << simunits->t.outscale * simunits->t.outcgs << endl;
-  cout << "rad_const : " << rad_const << endl;
-  cout << "stefboltz : " << stefboltz << endl;
-  cout << "rad_constscaled : " << rad_const*(simunits->E.outscale*simunits->E.outSI/
-    (pow(simunits->r.outscale*simunits->r.outSI,2)*simunits->t.outscale*simunits->t.outSI*
-     pow(simunits->temp.outscale*simunits->temp.outSI,4))) << endl;
 
-  // check that user wants cm2_g for opacity units
+  // Check for correct opacity units
   if (simunits ->kappa.outunit != "cm2_g") {
-    cout << "ERROR! Selected wrong unit for opacity. Use cm2_g" <<endl;
-    cout << simunits->kappa.outunit << endl;
-    ExceptionHandler::getIstance().raise("Error : Wrong units for opacity.  Use cm2_g");
+    ExceptionHandler::getIstance().raise("Error: Wrong units for opacity, use cm2_g");
   }
 
   ifstream file;
   file.open(radws_table.c_str(), ios::in);
-  // allocate table entries
-
-
-  cout << "EnergyRadws : " << radws_table << "  "<< file.good() << endl;
 
   //-----------------------------------------------------------------------------------------------
   if (file.good()) {
     getline(file, line);
-    cout << line << endl;
     istringstream istr(line);
     istr >> ndens >> ntemp ;
-
-    cout << "ndens, ntemp = " << ndens << "  " << ntemp << endl;
 
     eos_dens     = new FLOAT[ndens];
     eos_temp     = new FLOAT[ntemp];
     eos_energy   = new FLOAT*[ndens];
     eos_mu       = new FLOAT*[ndens];
+    eos_gamma    = new FLOAT*[ndens];
     kappa_table  = new FLOAT*[ndens];
     kappar_table = new FLOAT*[ndens];
     kappap_table = new FLOAT*[ndens];
 
-    for (i=0; i<ndens; i++){
+    for (i = 0; i < ndens; ++i){
       eos_energy[i]   = new FLOAT[ntemp];
       eos_mu[i]       = new FLOAT[ntemp];
+      eos_gamma[i]    = new FLOAT[ntemp];
       kappa_table[i]  = new FLOAT[ntemp];
       kappar_table[i] = new FLOAT[ntemp];
       kappap_table[i] = new FLOAT[ntemp];
@@ -129,26 +112,27 @@ EnergyRadws<ndim,ParticleType>::EnergyRadws
     while (getline(file, line)) {
       istringstream istr(line);
 
-      if (istr >> eos_dens_ >> eos_temp_ >> eos_energy_ >> eos_mu_>> kappa_ >> kappar_ >> kappap_) {
+      if (istr >> eos_dens_ >> eos_temp_ >> eos_energy_ >> eos_mu_>> kappa_ >> kappar_ >> kappap_ >> eos_gamma_) {
 
         eos_energy[i][j]   = eos_energy_/(simunits->u.outscale * simunits-> u.outcgs);
         eos_mu[i][j]       = eos_mu_;
+        eos_gamma[i][j]    = eos_gamma_;
         kappa_table[i][j]  = kappa_/(simunits->kappa.outscale * simunits-> kappa.outcgs);
         kappar_table[i][j] = kappar_/(simunits->kappa.outscale * simunits-> kappa.outcgs);
         kappap_table[i][j] = kappap_/(simunits->kappa.outscale * simunits-> kappa.outcgs);
 
         if (l < ntemp) {
           eos_temp[l] = log10(eos_temp_/(simunits->temp.outscale * simunits->temp.outcgs));
-        };
+        }
 
-        l += 1;
-        j += 1;
+        ++l;
+        ++j;
 
-        if (l % ntemp == 0) {
+        if (!(l % ntemp)) {
           eos_dens[i] = log10(eos_dens_/(simunits->rho.outscale * simunits-> rho.outcgs));
-          i += 1;
+          ++i;
           j = 0;
-        };
+        }
 
       } else cout << "Dateifehler" << endl;
 
@@ -158,19 +142,6 @@ EnergyRadws<ndim,ParticleType>::EnergyRadws
     file.close();
   }
   //-----------------------------------------------------------------------------------------------
-
-
-  //cout << getPosition_dens(test_dens) << endl;
-  //cout << getPosition_temp(test_temp) << endl;
-  //cout << kappap[getPosition_dens(test_dens)][getPosition_temp(test_temp)] << endl;
-
-  //////////////////// SAVE eos_dens and eos_temp in log10 ////////
-  //  eos_dens = log10(eos_dens);
-  // eos_temp = log10(eos_temp);
-
-  cout << "eos_dens=" <<eos_dens[0] << "  "<<eos_dens[ndens-1] <<endl ;
-  cout << "eos_temp="<< eos_temp[0]<< "  "<<eos_temp[ntemp-1] <<endl;
-
 }
 
 
@@ -182,12 +153,13 @@ EnergyRadws<ndim,ParticleType>::EnergyRadws
 template <int ndim, template <int> class ParticleType>
 EnergyRadws<ndim,ParticleType>::~EnergyRadws()
 {
-  for (int i=0; i<ndens; i++){
+  for (int i = 0; i < ndens; i++) {
     delete[] eos_energy[i];
     delete[] eos_mu[i];
     delete[] kappa_table[i];
     delete[] kappar_table[i];
     delete[] kappap_table[i];
+    delete[] eos_gamma[i];
   }
 
   delete[] eos_energy;
@@ -195,7 +167,7 @@ EnergyRadws<ndim,ParticleType>::~EnergyRadws()
   delete[] kappa_table;
   delete[] kappar_table;
   delete[] kappap_table;
-
+  delete[] eos_gamma;
 }
 
 
@@ -230,19 +202,18 @@ void EnergyRadws<ndim,ParticleType>::EnergyIntegration
     dt = t - part.tlast;
 
     if (part.dt_therm <= small_number) {
-      part.u = part.ueq;
-      //part.u = part.u0;
+      part.u = part.u0;
     }
-    else if (dt < (FLOAT) 40.0*part.dt_therm) {
-      part.u = part.u0*exp(-dt/part.dt_therm) + part.ueq*((FLOAT) 1.0 - exp(-dt/part.dt_therm));
+    else if (dt < (FLOAT) 40.0 * part.dt_therm) {
+      part.u = part.u0 * exp(-dt / part.dt_therm)
+             + part.ueq * ((FLOAT) 1.0 - exp(-dt / part.dt_therm));
     }
-    else if (dt >= (FLOAT) 40.0*part.dt_therm) {
+    else if (dt >= (FLOAT) 40.0 * part.dt_therm) {
       part.u = part.ueq;
     }
 
   }
   //-----------------------------------------------------------------------------------------------
-
 
   return;
 }
@@ -262,8 +233,8 @@ void EnergyRadws<ndim,ParticleType>::EndTimestep
 {
   int dn;                              // Integer time since beginning of step
   int i;                               // Particle counter
-  FLOAT temp;                          // ..
-  //FLOAT dt_therm;                      // ..
+  FLOAT temp;                          // Particle temperature
+
   ParticleType<ndim>* partdata = hydro->template GetParticleArray<ParticleType>();
 
   debug2("[EnergyRadws::EndTimestep]");
@@ -271,22 +242,25 @@ void EnergyRadws<ndim,ParticleType>::EndTimestep
 
 
   //-----------------------------------------------------------------------------------------------
-#pragma omp parallel for default(none) private(dn,i,temp) shared(partdata, hydro)
+#pragma omp parallel for default(none) private(dn,i,temp) shared(partdata, hydro,cout)
   for (i=0; i<hydro->Nhydro; i++) {
     ParticleType<ndim> &part = partdata[i];
     if (part.flags.is_dead()) continue;
     dn = n - part.nlast;
 
     if (part.flags.check(end_timestep)) {
-      temp = eos->Temperature(part);
+
+      temp = GetTemp(part);
 
       // Get new ueq and dt_therm
-      EnergyFindEqui(part.rho, temp, part.gpot, part.u, part.dudt,
+      // cout << part.gpot << "\t" << part.gpot_hydro << "\n";
+      EnergyFindEqui(part.rho, temp, part.gpot_hydro, part.u, part.dudt,
                      part.ueq, part.dt_therm, part.mu_bar);
-      part.u0 = part.u;
-      //part.dudt0 = part.dudt;
-    }
 
+
+      part.u0 = part.u;
+      part.dudt0 = part.dudt;
+    }
   }
   //-----------------------------------------------------------------------------------------------
 
@@ -336,30 +310,18 @@ void EnergyRadws<ndim,ParticleType>:: EnergyFindEqui
 
   // Calculate equilibrium temperature using implicit scheme described in Stamatellos et al. (2007)
   EnergyFindEquiTemp(idens, rho, temp, col2, dudt, Tequi, mu_bar_equi);
-  //assert(Tequi >= temp_ambient);
+  assert(Tequi >= temp_ambient);
 
+  // Get ueq_p and dudt_eq from Tequi
   logtemp = log10(Tequi);
   itemp = GetITemp(logtemp);
-
-
   GetKappa(idens, itemp, logrho, logtemp, kappa, kappar, kappap);
-  //ueq_p = GetEnergy(idens, itemp, logrho, logtemp);
-
-  ueq_p = Tequi / (0.66666666666666 * mu_bar_equi);
+  ueq_p = GetEnergy(idens, itemp, logrho, logtemp);
   dudt_eq = ebalance((FLOAT) 0.0 ,temp_ambient ,Tequi, kappa, kappap, col2);
 
-  //// GET CHANGE IN DUDT
-  dudt_tot = -(dudt_eq - dudt_rad);
-
-  /// Thermalization time scale
-  if (dudt_tot == 0.0){
-    dt_thermal = 1.e30;
-    cout << "Achtung dudt_tot == 0.0" << endl;
-  }
-  else {
-    dt_thermal = (ueq_p - u)/(dudt + dudt_rad);
-    //dt_thermal = (ueq_p - u)/(dudt + dudt_tot);
-  }
+  // Thermalization time scale
+  dt_thermal = (ueq_p - u) / (dudt + dudt_rad);
+  if (dudt_eq == dudt_rad) dt_thermal = 1E30;
 
   return;
 }
@@ -384,55 +346,49 @@ void EnergyRadws<ndim,ParticleType>::EnergyFindEquiTemp
   int itemplow, itemphigh;
 
   FLOAT accuracy = 0.001; // not shure what is a good accuracy (Paul)
-  FLOAT balance; //minbalance ;
+  FLOAT balance, minbalance;
   FLOAT balanceLow, balanceHigh ;
   FLOAT kappa, kappar, kappap;
   FLOAT kappaLow, kappaHigh, kappapLow, kappapHigh;
   FLOAT logtemp, logrho;
   FLOAT Tlow, Thigh, Tlow_log, Thigh_log, Tequi_log;
-  //FLOAT mu_bar_high, mu_bar_low;
+  FLOAT mu_bar_high, mu_bar_low;
   FLOAT dtemp;
 
   logrho = log10(rho);
-  logtemp = log10(temp);
 
+  logtemp = log10(temp);
   itemp = GetITemp(logtemp);
 
   // Rosseland and Planck opacities at rho_p and temperature temp(p)
   GetKappa(idens, itemp, logrho, logtemp, kappa, kappar, kappap);
-
-  // calculate radiative heating/cooling rate
   balance = ebalance((FLOAT) 0.0, temp_ambient, temp, kappa, kappap, col2);
 
-
-  // Rosseland and Planck opacities at rho_p and mintemperature 5K
-  //  tempmin = max(5.0,temp_ambient);
-  //logtemp = log10(tempmin);
-  //GetKappa(idens,  itemp,  logrho,  logtemp, kappa,  kappar, kappap);
-  // calculate minradiative heating/cooling rate
-  //minbalance = ebalance((FLOAT)0.0, temp_ambient , tempmin, kappa, kappap, col2);
+  // Get min. kappa and min balance
+  logtemp = log10(temp_ambient);
+  itemp = GetITemp(logtemp);
+  GetKappa(idens, itemp, logrho, logtemp, kappa, kappar, kappap);
+  minbalance = ebalance((FLOAT) 0.0, temp_ambient, temp_ambient, kappa, kappap, col2);
 
   // Find equilibrium temperature
   // ------------------------------------------------------------------------------------------------
-  if (dudt < -balance){                   // <=
+  if (dudt < -balance) {
+    if (dudt <= -minbalance){
+      Tequi = temp_ambient;
+      return;
+    }
 
-      //if (dudt <= -minbalance){
-    //if (dudt <= 0.0){
-      //Tequi = temp_ambient;
-      //return;
-    //}
-
-    //cout << "Cooling down" << endl;
     if (itemp <= 1) {
-      cout << "Leaving immediately!" << endl;
+      cout << "Reached itemp = 1, returning" << endl;
       Tequi = pow(10.0, eos_temp[1]);
       return;
     }
-    Tlow_log  = eos_temp[itemp-1];
+
+    Tlow_log  = eos_temp[itemp - 1];
     Tlow      = pow(10.0, Tlow_log);
-    Thigh_log = eos_temp[itemp+1];
+    Thigh_log = eos_temp[itemp + 1];
     Thigh     = pow(10.0, Thigh_log);
-    itemplow  = itemp-1;
+    itemplow  = itemp - 1;
 
     GetKappa(idens, itemplow, logrho, Tlow_log, kappaLow, kappar, kappapLow);
     balanceLow = ebalance(dudt, temp_ambient, Tlow, kappaLow, kappapLow, col2);
@@ -441,43 +397,35 @@ void EnergyRadws<ndim,ParticleType>::EnergyFindEquiTemp
     GetKappa(idens, itemphigh, logrho, Thigh_log, kappaHigh, kappar, kappapHigh);
     balanceHigh = ebalance(dudt, temp_ambient ,Thigh, kappaHigh, kappapHigh, col2);
 
-
-    while (balanceLow*balanceHigh > 0.0){
+    while (balanceLow * balanceHigh > 0.0){
       if (itemp <= 1) {
-        cout << "Reached itemp=1, returning" << endl;
+        cout << "Reached itemp = 1, returning" << endl;
         Tequi = pow(10.0, eos_temp[1]);
         return;
       }
 
-      Thigh       = Tlow ;
+      Thigh       = Tlow;
       kappaHigh   = kappaLow;
       kappapHigh  = kappapLow;
       balanceHigh = balanceLow;
-      itemplow    = itemplow -1;
+      itemplow    = itemplow - 1;
       Tlow_log    = eos_temp[itemplow];
       Tlow        = pow(10.0, Tlow_log);
 
       GetKappa(idens, itemplow, logrho, Tlow_log, kappaLow, kappar, kappapLow);
       balanceLow = ebalance(dudt, temp_ambient , Tlow, kappaLow, kappapLow, col2);
-
-      //GetKappa(idens,  itemphigh,  logrho,  Thigh_log, kappaHigh,  kappar, kappapHigh);
-      //balanceHigh = ebalance(dudt, temp_ambient , Thigh, kappaHigh, kappapHigh, col2);
-
     }
 
     itemphigh = itemplow + 1;
-    dtemp = Thigh - Tlow;
-  }
-  else {
-    // dudt > -balance; search higher temperatures
-    //    cout << "Heating up" << endl;
-    if (itemp >= ntemp-2) {
-      Tequi = pow(10.0, eos_temp[ntemp-2]);
+  } else {
+    if (itemp >= ntemp - 2) {
+      Tequi = pow(10.0, eos_temp[ntemp - 2]);
       return;
     }
-    Tlow_log  = eos_temp[itemp-1];
+
+    Tlow_log  = eos_temp[itemp - 1];
     Tlow      = pow(10.0, Tlow_log);
-    Thigh_log = eos_temp[itemp+1];
+    Thigh_log = eos_temp[itemp + 1];
     Thigh     = pow(10.0, Thigh_log);
 
     itemplow = itemp;
@@ -485,84 +433,66 @@ void EnergyRadws<ndim,ParticleType>::EnergyFindEquiTemp
     balanceLow = ebalance(dudt, temp_ambient, Tlow, kappaLow, kappapLow, col2);
 
     itemphigh = itemp + 1;
-    GetKappa(idens, itemphigh ,logrho, Thigh_log, kappaHigh, kappar, kappapHigh);
+    GetKappa(idens, itemphigh, logrho, Thigh_log, kappaHigh, kappar, kappapHigh);
     balanceHigh = ebalance(dudt, temp_ambient, Thigh, kappaHigh, kappapHigh, col2);
 
-    while (balanceLow*balanceHigh > 0.0) {
+    while (balanceLow * balanceHigh > 0.0) {
       if (itemp >= ntemp - 2) {
+        cout << "Reached itemp = ntemp, returning" << endl;
         Tequi = pow(10.0, eos_temp[ntemp - 2]);
         return;
       }
 
-      Tlow       = Thigh ;
+      Tlow       = Thigh;
       kappaLow   = kappaHigh;
       kappapLow  = kappapHigh;
       balanceLow = balanceHigh;
-      itemphigh  = itemphigh +1;
+      itemphigh  = itemphigh + 1;
       Thigh_log  = eos_temp[itemphigh];
       Thigh      = pow(10.0, Thigh_log);
 
-	  //GetKappa(idens,  itemplow,  logrho,  Tlow_log, kappaLow,  kappar, kappapLow);
-	  //balanceLow = ebalance(dudt, temp_ambient , Tlow, kappaLow, kappapLow, col2);
-
       GetKappa(idens, itemphigh, logrho, Thigh_log, kappaHigh, kappar, kappapHigh);
       balanceHigh = ebalance(dudt, temp_ambient, Thigh, kappaHigh, kappapHigh, col2);
-
     }
+
     itemplow = itemphigh - 1;
-    dtemp = Thigh - Tlow;
-
   }
-  //-----------------------------------------------------------------------------------------------
 
-
-  Tequi = 0.5*(Tlow + Thigh);
-  //dtemp = Thigh-Tlow;
-  //GetKappa(idens,  itemphigh,  logrho,  Thigh_log, kappaHigh,  kappar, kappapHigh);
-  //kappa = (kappaHigh + kappaLow)/2;
-  //kappap = (kappapHigh + kappapLow)/2;
-
+  Tequi = 0.5 * (Tlow + Thigh);
+  dtemp = Thigh - Tlow;
 
   // Refine the search in between Thigh and Tlow
   //-----------------------------------------------------------------------------------------------
-  while(fabs(2.*dtemp/(Thigh + Tlow)) > accuracy){
-
+  while (dtemp != 0.0 && fabs(2.0 * dtemp / (Thigh + Tlow)) > accuracy) {
+    Tequi_log = log10(Tequi);
     GetKappa(idens, itemplow, logrho, Tlow_log, kappaLow, kappar, kappapLow);
     balance = ebalance(dudt, temp_ambient , Tequi, kappa, kappap, col2);
 
     if (balance == 0.0) {
-      // LEAVE ROUTINE
-      Tequi = 0.5*(Thigh + Tlow);
+      Tequi = 0.5 * (Thigh + Tlow);
       return;
     }
 
-    if (balanceLow*balance < 0.0){
-      //cout <<  "cool " << endl;
+    if (balanceLow * balance < 0.0){
       Thigh       = Tequi;
       balanceHigh = balance;
       kappaHigh   = kappa;
       kappapHigh  = kappap;
-
     }
-    else{
-      //cout <<  "heat " << endl;
+    else {
       Tlow       = Tequi;
       balanceLow = balance;
       kappaLow   = kappa;
       kappapLow  = kappap;
     }
 
-    Tequi = 0.5*(Thigh + Tlow);
+    Tequi = 0.5 * (Thigh + Tlow);
+    kappa = (kappaHigh + kappaLow) / 2;
+    kappap = (kappapHigh + kappapLow) / 2;
     dtemp = Thigh - Tlow;
-   // mu_bar_equi = (mu_bar_high + mu_bar_low)/2;
-    kappa = (kappaHigh + kappaLow)/2;
-    kappap = (kappapHigh + kappapLow)/2;
   }
-  //----------------------------------------------------------------------------------------------
 
-  Tequi       = 0.5*(Thigh + Tlow);
-  Tequi_log   = log10(Tequi);
-  mu_bar_equi = GetMuBar(idens, itemplow, logrho, Tequi_log);
+  if (Tequi < temp_ambient) Tequi = temp_ambient;
 
   return;
 }
@@ -659,13 +589,12 @@ void EnergyRadws<ndim,ParticleType>::GetKappa
     kappa_table[idens][itemp+1]*epsilon*(1-delta) +
     kappa_table[idens][itemp]*(1-epsilon)*(1-delta);
 
-  //  kappar_loc = kappar[idens+1,itemp+1]*epsilon*delta + kappar[idens+1,itemp]*(1-epsilon)*delta +
-  //  kappar[idens,itemp+1]*epsilon*(1-delta) +kappar[idens,itemp]*(1-epsilon)*(1-delta);
-
   kappap = kappap_table[idens+1][itemp+1]*epsilon*delta +
     kappap_table[idens+1][itemp]*(1-epsilon)*delta +
     kappap_table[idens][itemp+1]*epsilon*(1-delta) +
     kappap_table[idens][itemp]*(1-epsilon)*(1-delta);
+
+  kappar = kappap;
 
   return;
 }
@@ -695,21 +624,17 @@ FLOAT EnergyRadws<ndim,ParticleType>::ebalance
 /// GetEnergy returns Energy  for index of density and temp
 //=================================================================================================
 
-/*template <int ndim, template <int> class ParticleType>
+template <int ndim, template <int> class ParticleType>
 FLOAT EnergyRadws<ndim,ParticleType>:: GetEnergy(int idens, int itemp, FLOAT logrho, FLOAT logtemp)
 {
-  FLOAT epsilon;
-  FLOAT delta;
+  const FLOAT epsilon = (logtemp - eos_temp[itemp])/(eos_temp[itemp+1] - eos_temp[itemp]);
+  const FLOAT delta = (logrho - eos_dens[idens])/(eos_dens[idens+1] - eos_dens[idens]);
 
-
- epsilon = (logtemp - eos_temp[itemp])/(eos_temp[itemp+1]-eos_temp[itemp]);         //log temp?
-  delta = (logrho - eos_dens[idens])/(eos_dens[idens+1]-eos_dens[idens]);
-
-
-  return eos_energy[idens+1][itemp+1]*epsilon*delta + eos_energy[idens+1][itemp]*(1-epsilon)*delta +
-    eos_energy[idens][itemp+1]*epsilon*(1-delta) +eos_energy[idens][itemp]*(1-epsilon)*(1-delta);
-
- }*/
+  return eos_energy[idens+1][itemp+1]*epsilon*delta +
+    eos_energy[idens+1][itemp]*(1 - epsilon)*delta +
+    eos_energy[idens][itemp+1]*epsilon*(1 - delta) +
+    eos_energy[idens][itemp]*(1 - epsilon)*(1 - delta);
+ }
 
 
 
@@ -731,6 +656,43 @@ FLOAT EnergyRadws<ndim,ParticleType>::GetMuBar
     eos_mu[idens+1][itemp]*(1 - epsilon)*delta +
     eos_mu[idens][itemp+1]*epsilon*(1 - delta) +
     eos_mu[idens][itemp]*(1 - epsilon)*(1 - delta);
+}
+
+
+
+//=================================================================================================
+//  EnergyRadws::GetTemp()
+/// GetTemp returns the temperature of particle form it's density and specific internal energy.
+/// The value is taken from the EoS table, not via a direct calculation.
+//=================================================================================================
+template <int ndim, template <int> class ParticleType>
+FLOAT EnergyRadws<ndim,ParticleType>::GetTemp
+ (Particle<ndim> &part)
+{
+  FLOAT result = temp_ambient;
+
+  FLOAT logrho = log10(part.rho);
+  int idens = GetIDens(logrho);
+
+  if (part.u == 0.0) return result;
+
+  int temp_index = -1;
+  FLOAT diff = 1E20;
+  for (int i = 0; i < ntemp; ++i) {
+    if (abs(part.u - eos_energy[idens][i]) < diff) {
+      diff = abs(part.u - eos_energy[idens][i]);
+      temp_index = i;
+    }
+  }
+
+  if (temp_index > ntemp - 1) temp_index = ntemp - 1;
+
+  result = pow10(eos_temp[temp_index]);
+
+  part.mu_bar = eos_mu[idens][temp_index];
+  part.gamma = eos_gamma[idens][temp_index];
+
+  return result;
 }
 
 

--- a/src/Hydrodynamics/EnergyRadws.cpp
+++ b/src/Hydrodynamics/EnergyRadws.cpp
@@ -252,7 +252,7 @@ void EnergyRadws<ndim,ParticleType>::EndTimestep
 
       temp = GetTemp(part);
 
-      EnergyFindEqui(part.rho, temp, part.gpot, part.u, part.dudt,
+      EnergyFindEqui(part.rho, temp, part.gpot_hydro, part.u, part.dudt,
                      part.ueq, part.dt_therm);
 
 

--- a/src/Hydrodynamics/Sph.cpp
+++ b/src/Hydrodynamics/Sph.cpp
@@ -133,6 +133,7 @@ void Sph<ndim>::ZeroAccelerations()
       part.div_v     = (FLOAT) 0.0;
       part.dudt      = (FLOAT) 0.0;
       part.gpot      = (FLOAT) 0.0;
+      part.gpot_hydro= (FLOAT) 0.0;
       for (int k=0; k<ndim; k++) part.a[k] = (FLOAT) 0.0;
       for (int k=0; k<ndim; k++) part.atree[k] = (FLOAT) 0.0;
     }

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -415,8 +415,6 @@ void SphSimulation<ndim>::PostInitialConditionsSetup(void)
       part.div_v     = (FLOAT) 0.0;
       part.dudt      = (FLOAT) 0.0;
       part.gpot      = (FLOAT) 0.0;
-      part.mu_bar    = (FLOAT) simparams->floatparams["mu_bar"];
-      part.gamma     = (FLOAT) simparams->floatparams["gamma_eos"];
       for (k=0; k<ndim; k++) part.a[k] = (FLOAT) 0.0;
       for (k=0; k<ndim; k++) part.atree[k] = (FLOAT) 0.0;
     }

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -416,6 +416,7 @@ void SphSimulation<ndim>::PostInitialConditionsSetup(void)
       part.dudt      = (FLOAT) 0.0;
       part.gpot      = (FLOAT) 0.0;
       part.mu_bar    = (FLOAT) simparams->floatparams["mu_bar"];
+      part.gamma     = (FLOAT) simparams->floatparams["gamma_eos"];
       for (k=0; k<ndim; k++) part.a[k] = (FLOAT) 0.0;
       for (k=0; k<ndim; k++) part.atree[k] = (FLOAT) 0.0;
     }

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -580,8 +580,6 @@ void MeshlessFVSimulation<ndim>::PostInitialConditionsSetup(void)
       part.nlast  = 0;
       part.tlast  = t;
       part.flags.set(active);
-      part.mu_bar    = (FLOAT) simparams->floatparams["mu_bar"];
-      part.gamma     = (FLOAT) simparams->floatparams["gamma"];
     }
     for (i=0; i<mfv->Nhydro; i++) mfv->GetMeshlessFVParticlePointer(i).flags.set(active);
 

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -580,6 +580,8 @@ void MeshlessFVSimulation<ndim>::PostInitialConditionsSetup(void)
       part.nlast  = 0;
       part.tlast  = t;
       part.flags.set(active);
+      part.mu_bar    = (FLOAT) simparams->floatparams["mu_bar"];
+      part.gamma     = (FLOAT) simparams->floatparams["gamma"];
     }
     for (i=0; i<mfv->Nhydro; i++) mfv->GetMeshlessFVParticlePointer(i).flags.set(active);
 

--- a/src/Thermal/RadwsEOS.cpp
+++ b/src/Thermal/RadwsEOS.cpp
@@ -35,8 +35,7 @@
 template <int ndim>
 Radws<ndim>::Radws(Parameters* simparams, SimUnits *units):
   EOS<ndim>(simparams->floatparams["gamma_eos"]),
-  temp0(simparams->floatparams["temp0"]/units->temp.outscale),
-  mu_bar(simparams->floatparams["mu_bar"])
+  temp0(simparams->floatparams["temp0"]/units->temp.outscale)
 {
 }
 

--- a/src/Thermal/RadwsEOS.cpp
+++ b/src/Thermal/RadwsEOS.cpp
@@ -43,12 +43,24 @@ Radws<ndim>::Radws(Parameters* simparams, SimUnits *units):
 
 
 //=================================================================================================
-//  Radws::Radws()
+//  Radws::~Radws()
 //=================================================================================================
 template <int ndim>
 Radws<ndim>::~Radws()
 {
 }
+
+
+//=================================================================================================
+//  Radws::Pressure
+/// Returns pressure of a particle based on a variable gamma
+//=================================================================================================
+template <int ndim>
+FLOAT Radws<ndim>::Pressure(Particle<ndim> &part)
+{
+  return (part.gamma - 1.0) * part.rho * part.u;
+}
+
 
 
 //=================================================================================================
@@ -59,7 +71,7 @@ Radws<ndim>::~Radws()
 template <int ndim>
 FLOAT Radws<ndim>::EntropicFunction(Particle<ndim> &part)
 {
-  return gammam1*part.u*pow(part.rho, (FLOAT) 1.0 - gamma);
+  return (part.gamma - 1.0)*part.u*pow(part.rho, (FLOAT) (1.0 - part.gamma));
 }
 
 
@@ -71,7 +83,7 @@ FLOAT Radws<ndim>::EntropicFunction(Particle<ndim> &part)
 template <int ndim>
 FLOAT Radws<ndim>::SoundSpeed(Particle<ndim> &part)
 {
-  return sqrt(gamma*gammam1*part.u);
+  return sqrt(part.gamma*(part.gamma - 1.0)*part.u);
 }
 
 
@@ -95,7 +107,7 @@ FLOAT Radws<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
 template <int ndim>
 FLOAT Radws<ndim>::Temperature(Particle<ndim> &part)
 {
-  return gammam1*part.u*part.mu_bar;
+  return (part.gamma - 1.0)*part.u*part.mu_bar;
 }
 
 


### PR DESCRIPTION
Fixed Radws EoS integration scheme. Requires EoS table with gamma. Added gpot_hydro to ignore sink potential.

The EoS pressure function is not inherited by the polytropic nor the radws EoS regimes. For now I have change the default pressure function to use part.gamma.