### PR TITLE
cd2010 viscosity fix

### DIFF
--- a/src/Headers/Sph.h
+++ b/src/Headers/Sph.h
@@ -453,7 +453,7 @@ Kernel<ndim>& kern)                                 ///< [in] Kernel
   if (alpha_loc > parti.alpha)
     parti.alpha = alpha_loc ;
 
-  parti.dalphadt = (FLOAT)0.1*parti.sound*(alpha_visc_min - parti.alpha)*invh;
+  parti.dalphadt = (FLOAT)0.1*parti.sound*(max(alpha_visc_min, alpha_loc) - parti.alpha)*invh;
 }
 
 

--- a/src/Hydrodynamics/Sph.cpp
+++ b/src/Hydrodynamics/Sph.cpp
@@ -129,7 +129,6 @@ void Sph<ndim>::ZeroAccelerations()
     SphParticle<ndim>& part = GetSphParticlePointer(i);
     if (part.flags.check(active)) {
       part.levelneib = 0;
-      part.dalphadt  = (FLOAT) 0.0;
       part.div_v     = (FLOAT) 0.0;
       part.dudt      = (FLOAT) 0.0;
       part.gpot      = (FLOAT) 0.0;


### PR DESCRIPTION
A small fix which removes the zeroing of dalphadt before it is used by the Cullen & Dehnen (2010) viscosity method.