### PR TITLE
Made dust use dimensional units (where valid)

### DIFF
--- a/docs/userguide.tex
+++ b/docs/userguide.tex
@@ -2040,22 +2040,11 @@ are conserved explicitly, while in the test-particle limit these are conserved f
 \end{itemize}
 
 \subsection{Drag Laws}
-Several drag laws have been implemented in via functions form of $t_s \equiv t_s (\rho_g , \rho_d , c_s)$. The different functional forms currently available can be chosen via the parameter options and are described below and are defined in src/Headers/DragLaws.h. Most of these drag laws are phenomelogical in form, and only work with dimensionionless form. The one exception is the Epstein drag law. Each drag law is currently controlled by a single coefficient, the \var{drag\_coeff} ($K_\mathrm{d}$).
-
-
-Drag laws ($\rho_d$ is set to 0 in the \var{test\_particle} implementation):
-\begin{itemize}
-\item \var{fixed} --  $t_s  = 1 / K_\mathrm{d}$
-
-\item \var{density} -- $t_s  = 1 / ((\rho_d + \rho_g) K_\mathrm{d})$
-
-\item \var{epstein} -- The Epstein drag law, which is valid for paricles with size, $a < 4\lambda/9$, where $\lambda$ is the mean free path of the gas (see Booth, Sijacki  \& Clarke 2015).  \var{drag\_coeff} is the mass-to-area ratio of the grains (i.e. $4 \rho_\mathrm{s} a / 3$, for spherical grains of  material density, $\rho_\mathrm{a}$.). If non-dimensionless units are used, this \emph{must} be specified in c.g.s units.
-
-\item \var{LP2012} -- The drag law from Laibe \& Price (2012), $t_s = \rho_d \rho_g / ((\rho_d + \rho_g) K_\mathrm{d})$, as used in equations (1) and (2) above.
-
-\end{itemize}
-
-Including additional drag forces is straight forward. First add a new class to src/Headers/DragLaws.h. The new drag law can then be added to DustFactory::ProcessParameters (at the bottom of src/Common/Dust.cpp), which is responsible for selecting the desired drag law.
+Several drag laws have been implemented in via functions form of $t_s \equiv t_s (\rho_g , \rho_d , c_s)$. The different functional forms currently available can be chosen via the parameter options and are described below and are defined in src/Headers/DragLaws.h. Most of these drag laws are phenomelogical in form, and only work with dimensionionless form. The one exception is the Epstein drag law, in which the stopping time is given by:
+\begin{equation}
+t_s = \frac{3}{4} \sqrt{\frac{\pi}{8}} \frac{m}{A(\rho_g + \rho_d)c_s},
+\end{equation}
+where $m$ is the grain mass and $A$ is its grain area ($\pi a^2$ for spherical grains). In the code, absorb the area-to-mass ratio into a single coefficient.
 
 
 \subsection{IO and initial conditions}
@@ -2082,7 +2071,7 @@ full twofluid     & = Full two fluid drag regime
 \begin{tabular}{ll}
 fixed             & $t_s = 1 / K_D$ \\
 density           & $t_s = 1 / (K_D(\rho_d + \rho_g))$ \\
-epstein           & $t_s = 1 / (K_D(\rho_d + \rho_g)c_s)$ \\
+epstein           & $t_s = \frac{(3/4) \sqrt{\pi/8}}{K_D(\rho_d + \rho_g)c_s}$, where $K_D$ is the area-to-mass ratio \\
 LB2012            & $t_s = \rho_d \rho_g / (K_D(\rho_d + \rho_g))$ \\
 \end{tabular}
 
@@ -2091,6 +2080,8 @@ LB2012            & $t_s = \rho_d \rho_g / (K_D(\rho_d + \rho_g))$ \\
 \item \var{dust\_mass\_factor} : Sets the dust-to-gas mass ratio for the test problems
 
 \end{itemize}
+
+Including additional drag forces is straight forward. First add a new class to src/Headers/DragLaws.h. The new drag law can then be added to DustFactory::ProcessParameters (at the bottom of src/Common/Dust.cpp), which is responsible for selecting the desired drag law.
 
 \newpage
 

--- a/docs/userguide.tex
+++ b/docs/userguide.tex
@@ -2040,7 +2040,23 @@ are conserved explicitly, while in the test-particle limit these are conserved f
 \end{itemize}
 
 \subsection{Drag Laws}
-Several drag laws have been implemented in via functions form of $t_s \equiv t_s (\rho_g , \rho_d , c_s)$. The different functional forms currently available can be chosen via the parameter options and are described below. The drag laws are defined in src/Headers/DragLaws.h. Currently only dimensionless units are supported when setting the stopping time.
+Several drag laws have been implemented in via functions form of $t_s \equiv t_s (\rho_g , \rho_d , c_s)$. The different functional forms currently available can be chosen via the parameter options and are described below and are defined in src/Headers/DragLaws.h. Most of these drag laws are phenomelogical in form, and only work with dimensionionless form. The one exception is the Epstein drag law. Each drag law is currently controlled by a single coefficient, the \var{drag\_coeff} ($K_\mathrm{d}$).
+
+
+Drag laws ($\rho_d$ is set to 0 in the \var{test\_particle} implementation):
+\begin{itemize}
+\item \var{fixed} --  $t_s  = 1 / K_\mathrm{d}$
+
+\item \var{density} -- $t_s  = 1 / ((\rho_d + \rho_g) K_\mathrm{d})$
+
+\item \var{epstein} -- The Epstein drag law, which is valid for paricles with size, $a < 4\lambda/9$, where $\lambda$ is the mean free path of the gas (see Booth, Sijacki  \& Clarke 2015).  \var{drag\_coeff} is the mass-to-area ratio of the grains (i.e. $4 \rho_\mathrm{s} a / 3$, for spherical grains of  material density, $\rho_\mathrm{a}$.). If non-dimensionless units are used, this \emph{must} be specified in c.g.s units.
+
+\item \var{LP2012} -- The drag law from Laibe \& Price (2012), $t_s = \rho_d \rho_g / ((\rho_d + \rho_g) K_\mathrm{d})$, as used in equations (1) and (2) above.
+
+\end{itemize}
+
+Including additional drag forces is straight forward. First add a new class to src/Headers/DragLaws.h. The new drag law can then be added to DustFactory::ProcessParameters (at the bottom of src/Common/Dust.cpp), which is responsible for selecting the desired drag law.
+
 
 \subsection{IO and initial conditions}
 Dust particles are currently supported only in the SEREN formats (both formatted and unformatted), with the dust particles following the gas particles on the disc. The number of dust particles is stored in the header, as described in section \ref{Sec:SerenForm}. The column format is \emph{not} formally supported, but if used it will currently still contain the dust particles after the gas particles as long as MPI is not used. However, the number of dust particles is not currently saved in the column format.

--- a/src/Common/Dust.cpp
+++ b/src/Common/Dust.cpp
@@ -1162,7 +1162,7 @@ DustBase<ndim>* ProcessParameters(Parameters* simparams, ParticleTypeRegister& t
 
 	double K_D  = floatparams["drag_coeff"] ;
 	if (intparams["dimensionless"] == 0 && DragLaw == "epstein") {
-	  // sigma is mass / area, K_D is are / mass
+	  // sigma is mass / area, K_D is area / mass
 	  K_D = 1 / units.sigma.CGS_to_CodeUnits(1 / K_D);
 	}
 

--- a/src/Common/Dust.cpp
+++ b/src/Common/Dust.cpp
@@ -1162,8 +1162,8 @@ DustBase<ndim>* ProcessParameters(Parameters* simparams, ParticleTypeRegister& t
 
 	double K_D  = floatparams["drag_coeff"] ;
 	if (intparams["dimensionless"] == 0 && DragLaw == "epstein") {
-	  // sigma is mass / area, just what we need.
-	  K_D = units.sigma.CGS_to_CodeUnits(K_D);
+	  // sigma is mass / area, K_D is are / mass
+	  K_D = 1 / units.sigma.CGS_to_CodeUnits(1 / K_D);
 	}
 
 	if (DustForces == "test_particle")

--- a/src/Common/Dust.cpp
+++ b/src/Common/Dust.cpp
@@ -1149,7 +1149,7 @@ template<int ndim, template<int> class ParticleType, class StoppingTime, class K
 class _DustFactoryKern
 {
 public:
-DustBase<ndim>* ProcessParameters(Parameters* simparams, ParticleTypeRegister& types,
+DustBase<ndim>* ProcessParameters(Parameters* simparams, ParticleTypeRegister& types, SimUnits& units,
 							      TreeBase<ndim>* t, TreeBase<ndim>* ghost, TreeBase<ndim>* mpi_tree)
 {
 	map<string, double> &floatparams = simparams->floatparams;
@@ -1157,8 +1157,14 @@ DustBase<ndim>* ProcessParameters(Parameters* simparams, ParticleTypeRegister& t
     map<string, int> &intparams = simparams->intparams;
 	string KernelName = stringparams["kernel"];
 	string DustForces = stringparams["dust_forces"];
+    string DragLaw = stringparams["drag_law"];
+
 
 	double K_D  = floatparams["drag_coeff"] ;
+	if (intparams["dimensionless"] == 0 && DragLaw == "epstein") {
+	  // sigma is mass / area, just what we need.
+	  K_D = units.sigma.CGS_to_CodeUnits(K_D);
+	}
 
 	if (DustForces == "test_particle")
 	{
@@ -1212,7 +1218,7 @@ class _DustFactoryStop
 {
 public:
 
-DustBase<ndim>* ProcessParameters(Parameters * simparams, ParticleTypeRegister& types,
+DustBase<ndim>* ProcessParameters(Parameters* simparams, ParticleTypeRegister& types, SimUnits& units,
 							      TreeBase<ndim>* t, TreeBase<ndim>* ghost, TreeBase<ndim>* mpi_tree)
 {
 	map<string, int> &intparams = simparams->intparams;
@@ -1221,22 +1227,22 @@ DustBase<ndim>* ProcessParameters(Parameters * simparams, ParticleTypeRegister& 
 
 	if (intparams["tabulated_kernel"] == 1) {
 		_DustFactoryKern<ndim, ParticleType, StoppingTime, TabulatedKernel<ndim> > DF;
-		return DF.ProcessParameters(simparams, types, t, ghost, mpi_tree);
+		return DF.ProcessParameters(simparams, types, units, t, ghost, mpi_tree);
 	  }
 
 	  else if (intparams["tabulated_kernel"] == 0) {
 	    // Depending on the kernel, instantiate a different GradSph object
 	    if (KernelName == "m4") {
 			_DustFactoryKern<ndim, ParticleType, StoppingTime, M4Kernel<ndim> > DF;
-			return DF.ProcessParameters(simparams, types, t, ghost, mpi_tree);
+			return DF.ProcessParameters(simparams, types, units, t, ghost, mpi_tree);
 	    }
 	    else if (KernelName == "quintic") {
 			_DustFactoryKern<ndim, ParticleType, StoppingTime, QuinticKernel<ndim> > DF;
-			return DF.ProcessParameters(simparams, types, t, ghost, mpi_tree);
+			return DF.ProcessParameters(simparams, types, units, t, ghost, mpi_tree);
 	    }
 	    else if (KernelName == "gaussian") {
 			_DustFactoryKern<ndim, ParticleType, StoppingTime, GaussianKernel<ndim> > DF;
-			return DF.ProcessParameters(simparams, types, t, ghost, mpi_tree);
+			return DF.ProcessParameters(simparams, types, units, t, ghost, mpi_tree);
 	    }
 	    else {
 	      string message = "Unrecognised parameter : kernel = " + simparams->stringparams["kernel"];
@@ -1265,6 +1271,7 @@ template<int ndim, template<int> class ParticleType>
 DustBase<ndim>* DustFactory<ndim, ParticleType>::ProcessParameters
 (Parameters * simparams,
 CodeTiming * timing,
+SimUnits& units,
 ParticleTypeRegister& types,
 DomainBox<ndim>& simbox,
 TreeBase<ndim>* t,
@@ -1284,9 +1291,9 @@ TreeBase<ndim>* mpi_tree)
 	}
 
 
-	if (intparams["dimensionless"] == 0){
+	if (intparams["dimensionless"] == 0 && DragLaw != "epstein"){
 	  ExceptionHandler::getIstance().raise("Error: Non-dimensionless simulations with dust are "
-			  	  	  	  	  	  	  	   "not currently supported") ;
+			  	  	  	  	  	  	  	   "only supported with epstein drag") ;
 	}
 
 	DustBase<ndim> * dust_forces ;
@@ -1294,19 +1301,19 @@ TreeBase<ndim>* mpi_tree)
 	// Depending on the kernel, instantiate a different GradSph object
 	if (DragLaw == "fixed") {
 		_DustFactoryStop<ndim, ParticleType, FixedDrag> DF ;
-		dust_forces = DF.ProcessParameters(simparams, types, t, ghost, mpi_tree) ;
+		dust_forces = DF.ProcessParameters(simparams, types, units, t, ghost, mpi_tree) ;
 	}
 	else if (DragLaw == "density") {
 		_DustFactoryStop<ndim, ParticleType, DensityDrag> DF ;
-		dust_forces = DF.ProcessParameters(simparams, types, t, ghost, mpi_tree) ;
+		dust_forces = DF.ProcessParameters(simparams, types, units, t, ghost, mpi_tree) ;
 	}
 	else if (DragLaw == "epstein") {
 		_DustFactoryStop<ndim, ParticleType, EpsteinDrag> DF ;
-		dust_forces = DF.ProcessParameters(simparams, types, t, ghost, mpi_tree) ;
+		dust_forces = DF.ProcessParameters(simparams, types, units, t, ghost, mpi_tree) ;
 	}
 	else if (DragLaw == "LP2012") {
 	    _DustFactoryStop<ndim, ParticleType, LP12_Drag> DF ;
-	    dust_forces = DF.ProcessParameters(simparams, types, t, ghost, mpi_tree) ;
+	    dust_forces = DF.ProcessParameters(simparams, types, units, t, ghost, mpi_tree) ;
 	}
 	else {
 		string message = "Unrecognised parameter : drag_law = " + simparams->stringparams["drag_law"];

--- a/src/GradhSph/GradhSphSimulation.cpp
+++ b/src/GradhSph/GradhSphSimulation.cpp
@@ -332,8 +332,9 @@ void GradhSphSimulation<ndim>::ProcessSphParameters(void)
 
   // Setup the dust force object
   //-----------------------------------------------------------------------------------------------
-  sphdust = DustFactory<ndim, GradhSphParticle>::ProcessParameters(simparams, timing, sph->types,
-                                                                   simbox, t, gt, mpit) ;
+  sphdust = DustFactory<ndim, GradhSphParticle>::ProcessParameters(simparams, timing, simunits,
+                                                                   sph->types, simbox,
+                                                                   t, gt, mpit) ;
 
 #if defined MPI_PARALLEL
   if (sphdust != NULL) sphdust->SetMpiControl(mpicontrol);

--- a/src/Headers/DragLaws.h
+++ b/src/Headers/DragLaws.h
@@ -70,6 +70,8 @@ private:
 /// \author  R. A. Booth
 /// \date    17/10/2015
 //=================================================================================================
+// EpsteinNorm = 3 sqrt(pi/8) / 4
+static const double EpsteinNorm = 0.4699928014933126;
 class EpsteinDrag
 {
 public:
@@ -77,7 +79,7 @@ public:
 	: _K_d(DragCoeff)
 	{ } ;
 	FLOAT operator()(FLOAT grho, FLOAT drho, FLOAT gsound) const
-		{ return 1. / ((grho + drho) * gsound * _K_d) ; }
+		{ return EpsteinNorm / ((grho + drho) * gsound * _K_d) ; }
 private:
 	FLOAT _K_d ;
 };

--- a/src/Headers/Dust.h
+++ b/src/Headers/Dust.h
@@ -30,6 +30,7 @@
 #include "Constants.h"
 #include "CodeTiming.h"
 #include "InlineFuncs.h"
+#include "SimUnits.h"
 #include "Tree.h"
 
 template<int ndim> class MpiControl;
@@ -72,7 +73,7 @@ template<int ndim, template<int> class ParticleType>
 class DustFactory
 {
 public:
-  static DustBase<ndim>* ProcessParameters(Parameters* params, CodeTiming* timing,
+  static DustBase<ndim>* ProcessParameters(Parameters* params, CodeTiming* timing, SimUnits& units,
 		  	  	  	  	  	  	  	  	   ParticleTypeRegister& types,
 		  	  	  	  	  	  	  	  	   DomainBox<ndim>& simbox,
 							               TreeBase<ndim>* t, TreeBase<ndim>* ghost,

--- a/src/Headers/SimUnits.h
+++ b/src/Headers/SimUnits.h
@@ -59,6 +59,19 @@ class SimUnit
   string inunit;                           ///< Input unit string
   string outunit;                          ///< Output unit string
 
+  // Helper functions (to implement)
+  double InputUnits_to_CodeUnits(double input_unit) {};
+  double OutputUnits_to_CodeUnits(double output_unit){};
+  double CodeUnits_to_InputUnits(double code_unit){};
+  double CodeUnits_to_Outputnits(double code_unit){};
+
+  double SI_to_CodeUnits(double SI_unit){};
+  double CGS_to_CodeUnits(double CGS_unit){};
+  double CodeUnits_to_SI(double code_unit){};
+  double CodeUnits_to_CGS(double code_unit){};
+
+
+
 };
 
 

--- a/src/Headers/SimUnits.h
+++ b/src/Headers/SimUnits.h
@@ -59,18 +59,17 @@ class SimUnit
   string inunit;                           ///< Input unit string
   string outunit;                          ///< Output unit string
 
-  // Helper functions (to implement)
-  double InputUnits_to_CodeUnits(double input_unit) {};
-  double OutputUnits_to_CodeUnits(double output_unit){};
-  double CodeUnits_to_InputUnits(double code_unit){};
-  double CodeUnits_to_Outputnits(double code_unit){};
 
-  double SI_to_CodeUnits(double SI_unit){};
-  double CGS_to_CodeUnits(double CGS_unit){};
-  double CodeUnits_to_SI(double code_unit){};
-  double CodeUnits_to_CGS(double code_unit){};
+  // Helper functions for converting between code and physical units
+  inline DOUBLE Input_to_CodeUnits(const DOUBLE value) {return (value/inscale);}
+  inline DOUBLE Output_to_CodeUnits(const DOUBLE value) {return (value/outscale);}
+  inline DOUBLE Code_to_InputUnits(const DOUBLE value) {return (value*inscale);}
+  inline DOUBLE Code_to_OutputUnits(const DOUBLE value) {return (value*outscale);}
 
-
+  inline DOUBLE SI_to_CodeUnits(const DOUBLE value) {return (value/(outscale*outSI));}
+  inline DOUBLE CGS_to_CodeUnits(const DOUBLE value) {return (value/(outscale*outcgs));}
+  inline DOUBLE Code_to_SIUnits(const DOUBLE value) {return (value*outscale*outSI);}
+  inline DOUBLE Code_to_CGSUnits(const DOUBLE value) {return (value*outscale*outcgs);}
 
 };
 

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -244,8 +244,9 @@ void MeshlessFVSimulation<ndim>::ProcessParameters(void)
 #endif
 
   // Setup the dust
-  mfvdust = DustFactory<ndim, MeshlessFVParticle>::ProcessParameters(simparams, timing, mfv->types,
-                                                                     simbox, t, gt, mpit) ;
+  mfvdust = DustFactory<ndim, MeshlessFVParticle>::ProcessParameters(simparams, timing, simunits,
+                                                                     mfv->types, simbox,
+                                                                     t, gt, mpit) ;
 
 #if defined MPI_PARALLEL
  if (mfvdust != NULL) mfvdust->SetMpiControl(mpicontrol);

--- a/tests/dust_tests/dustywave_sol.py
+++ b/tests/dust_tests/dustywave_sol.py
@@ -136,6 +136,8 @@ def DustyWave(sim, time):
     # Approximate the epstein drag coefficient
     if simstringparams["drag_law"] == "LP2012":
         K *= csound / (rho_g*rho_g*eps)
+    else:
+        K /= 0.4699928014933126
 
     solver = DustyWaveSolver(rho_g, rho_g*eps, csound, K, delta,
                              wlambda, feedback)

--- a/tests/dust_tests/plot_dustywave.py
+++ b/tests/dust_tests/plot_dustywave.py
@@ -54,9 +54,11 @@ if __name__=="__main__":
 
     # Plot the numerical and analytical solutions
     plt.plot(x_gas, vx_gas,           'k.')
+    x_gas.sort()
     plt.plot(x_gas, sol.v_gas(x_gas), 'k' )
 
     plt.plot(x_dust, vx_dust,            'r.')
+    x_dust.sort()
     plt.plot(x_dust, sol.v_dust(x_dust), 'r' )
     
     plt.xlabel('x')

--- a/tests/dust_tests/test_dustywave.py
+++ b/tests/dust_tests/test_dustywave.py
@@ -11,8 +11,8 @@ class DustyWaveTest(unittest.TestCase):
         self.run_id="DUSTYWAVE_SPH"
         self.sim.SetParam("drag_law", "epstein")
         self.sim.SetParam("run_id",self.run_id)
-        self.expected_l1error_gas  = 2.1e-6
-        self.expected_l1error_dust = 1.5e-5
+        self.expected_l1error_gas  = 2.2e-6
+        self.expected_l1error_dust = 6.0e-7
     
 
     def test_error(self):
@@ -53,5 +53,5 @@ class DustyWaveTestMeshless(DustyWaveTest):
         self.run_id="DUSTYWAVE_MFV"
         self.sim.SetParam("run_id",self.run_id)
         self.expected_l1error_gas  = 1.6e-5
-        self.expected_l1error_dust = 7.7e-7
+        self.expected_l1error_dust = 8.2e-7
 

--- a/tests/dust_tests/test_dustywave.py
+++ b/tests/dust_tests/test_dustywave.py
@@ -11,8 +11,8 @@ class DustyWaveTest(unittest.TestCase):
         self.run_id="DUSTYWAVE_SPH"
         self.sim.SetParam("drag_law", "epstein")
         self.sim.SetParam("run_id",self.run_id)
-        self.expected_l1error_gas  = 4.1e-6
-        self.expected_l1error_dust = 2.3e-5
+        self.expected_l1error_gas  = 2.1e-6
+        self.expected_l1error_dust = 1.5e-5
     
 
     def test_error(self):
@@ -53,5 +53,5 @@ class DustyWaveTestMeshless(DustyWaveTest):
         self.run_id="DUSTYWAVE_MFV"
         self.sim.SetParam("run_id",self.run_id)
         self.expected_l1error_gas  = 1.6e-5
-        self.expected_l1error_dust = 5.7e-7
+        self.expected_l1error_dust = 7.7e-7
 


### PR DESCRIPTION
This branch introduces dimensional units into the dust. I've had a nightmare understanding just how to use the classes properly, so I've introduced some helper functions in SimUnits.h that still need implementing. I don't trust myself to do this correctly so David, can you do it? This should only take 2 minutes.