### PR TITLE
Preventing overwrite of iorig on restart

### DIFF
--- a/src/Common/SimulationIO.hpp
+++ b/src/Common/SimulationIO.hpp
@@ -847,14 +847,19 @@ bool Simulation<ndim>::ReadSerenFormSnapshotFile(string filename)
       sink_data_length = 12 + 2*ndim;  //+ 2*dmdt_range_aux;
       int ii;
       FLOAT sdata[sink_data_length];
-      for (ii=0; ii<6; ii++) infile >> idata[ii];
+      int junk[6] = { 2, 2, 0, sink_data_length, 0, 0} ;
+      for (ii=0; ii<6; ii++) {
+        int itmp;
+        infile >> itmp;
+        assert(itmp == junk[ii]);
+      }
       if (nbody->Nstar > 0) {
         for (i=0; i<nbody->Nstar; i++) {
           for (ii=0; ii<2; ii++) {
             char boolean;
             infile >> boolean;
           }
-          for (ii=0; ii<2; ii++) infile >> idata[ii];
+          for (ii=0; ii<2; ii++) infile >> junk[ii];
           for (ii=0; ii<sink_data_length; ii++) infile >> sdata[ii];
           for (k=0; k<ndim; k++) nbody->stardata[i].r[k] = sdata[k+1];
           for (k=0; k<ndim; k++) nbody->stardata[i].v[k] = sdata[k+1+ndim];
@@ -1500,7 +1505,12 @@ bool Simulation<ndim>::ReadSerenUnformSnapshotFile(string filename)
       int ii;
       FLOAT sdata[sink_data_length];
       int idata[50];
-      for (ii=0; ii<6; ii++) reader.read_value(idata[ii]);
+      int junk[6] = {2,2,0, sink_data_length, 0,0};
+      for (ii=0; ii<6; ii++) {
+        int itmp;
+        reader.read_value(itmp);
+        assert(itmp == junk[6]);
+      }
       if (nbody->Nstar > 0) {
         for (int i=0; i<nbody->Nstar; i++) {
           //Logical flags
@@ -1508,7 +1518,7 @@ bool Simulation<ndim>::ReadSerenUnformSnapshotFile(string filename)
             int boolean;
             reader.read_value(boolean);
           }
-          for (ii=0; ii<2; ii++) reader.read_value(idata[ii]);
+          for (ii=0; ii<2; ii++) reader.read_value(junk[ii]);
           for (ii=0; ii<sink_data_length; ii++) reader.read_value(sdata[ii]);
           for (int k=0; k<ndim; k++) nbody->stardata[i].r[k] = sdata[k+1];
           for (int k=0; k<ndim; k++) nbody->stardata[i].v[k] = sdata[k+1+ndim];

--- a/src/Common/SimulationIO.hpp
+++ b/src/Common/SimulationIO.hpp
@@ -1509,7 +1509,7 @@ bool Simulation<ndim>::ReadSerenUnformSnapshotFile(string filename)
       for (ii=0; ii<6; ii++) {
         int itmp;
         reader.read_value(itmp);
-        assert(itmp == junk[6]);
+        assert(itmp == junk[ii]);
       }
       if (nbody->Nstar > 0) {
         for (int i=0; i<nbody->Nstar; i++) {

--- a/src/Hydrodynamics/SphSimulation.cpp
+++ b/src/Hydrodynamics/SphSimulation.cpp
@@ -210,7 +210,7 @@ void SphSimulation<ndim>::PostInitialConditionsSetup(void)
   sph->DeleteDeadParticles();
 
   // Set iorig
-  if (rank == 0) {
+  if (rank == 0 && not restart) {
     for (i=0; i<sph->Nhydro; i++) sph->GetSphParticlePointer(i).iorig = i;
   }
 

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -403,7 +403,9 @@ void MeshlessFVSimulation<ndim>::PostInitialConditionsSetup(void)
   if (rank == 0) {
     MeshlessFVParticle<ndim> *partdata = mfv->GetMeshlessFVParticleArray();
     for (i=0; i<mfv->Nhydro; i++) {
-      partdata[i].iorig = i;
+      if (not restart) {
+        partdata[i].iorig = i;
+      }
       partdata[i].flags.set(active);
       partdata[i].flags.set(update_density) ;
       partdata[i].gpot = big_number;


### PR DESCRIPTION
We were re-setting iorig on restarts, which I don't think is the correct behaviour. This now skips it.