### PR TITLE
Mfv eos - Radws

### DIFF
--- a/src/Common/Dust.cpp
+++ b/src/Common/Dust.cpp
@@ -402,7 +402,6 @@ void DustSphNgbFinder<ndim, ParticleType>::FindNeibAndDoInterp
   typedef typename Interpolant::DataType InterpData;
 
   ParticleType<ndim>* sphdata = hydro->template GetParticleArray<ParticleType>();
-  int Nhydro = hydro->Nhydro ;
 
   int cactive;                             // No. of active tree cells
   vector<TreeCellBase<ndim> > celllist;    // List of active cells
@@ -421,7 +420,7 @@ void DustSphNgbFinder<ndim, ParticleType>::FindNeibAndDoInterp
 
   // Set-up all OMP threads
   //===============================================================================================
-#pragma omp parallel default(none) shared(cactive,celllist,cout,sphdata, mask, Interp, Nhydro)
+#pragma omp parallel default(none) shared(cactive,celllist,cout,sphdata, mask, Interp)
  {
     int celldone;                              // Flag if cell is done
     int cc;                                    // Aux. cell counter

--- a/src/Common/SimulationIO.hpp
+++ b/src/Common/SimulationIO.hpp
@@ -1504,7 +1504,6 @@ bool Simulation<ndim>::ReadSerenUnformSnapshotFile(string filename)
       int sink_data_length = 12 + 2*ndim;  //+ 2*dmdt_range_aux;
       int ii;
       FLOAT sdata[sink_data_length];
-      int idata[50];
       int junk[6] = {2,2,0, sink_data_length, 0,0};
       for (ii=0; ii<6; ii++) {
         int itmp;

--- a/src/Headers/CommunicationHandler.h
+++ b/src/Headers/CommunicationHandler.h
@@ -170,29 +170,29 @@ class MeshlessCommunicationHandler {
   struct MeshlessExportParticle {
 
     MeshlessExportParticle (const MeshlessFVParticle<ndim>& p) {
-        iorig = p.iorig;
-        flags = p.flags.get();
-        ptype = p.ptype;
-        level = p.level;
-        nstep = p.nstep;
-    	for (int k=0; k<ndim; k++) {
-    		r[k] = p.r[k];
-    		v[k] = p.v[k];
-    		for (int kk=0; kk<ndim; kk++) {
-    			B[k][kk]=p.B[k][kk];
-    		}
-    	}
-    	for (int ivar=0; ivar<ndim+2; ivar++) {
-    		Wprim[ivar]=p.Wprim[ivar];
-    		alpha_slope[ivar]=p.alpha_slope[ivar];
-    		for (int k=0; k<ndim; k++) {
-        		grad[ivar][k] = p.grad[ivar][k];
-    		}
-    	}
-    	m = p.m;
-    	ndens = p.ndens;
-    	vsig_max = p.vsig_max;
-    	sound = p.sound;
+      iorig = p.iorig;
+      flags = p.flags.get();
+      ptype = p.ptype;
+      level = p.level;
+      nstep = p.nstep;
+      for (int k=0; k<ndim; k++) {
+        r[k] = p.r[k];
+        v[k] = p.v[k];
+        for (int kk=0; kk<ndim; kk++) {
+          B[k][kk]=p.B[k][kk];
+        }
+      }
+      for (int ivar=0; ivar<ndim+2; ivar++) {
+        Wprim[ivar]=p.Wprim[ivar];
+        alpha_slope[ivar]=p.alpha_slope[ivar];
+        for (int k=0; k<ndim; k++) {
+          grad[ivar][k] = p.grad[ivar][k];
+        }
+      }
+      m = p.m;
+      ndens = p.ndens;
+      vsig_max = p.vsig_max;
+      sound = p.sound;
     }
 
     int iorig;
@@ -217,13 +217,13 @@ class MeshlessCommunicationHandler {
     MeshlessForcesParticle (const MeshlessFVParticle<ndim>& p) {
 
       for (int k=0; k<ndim; k++) {
-    	  rdmdt[k]=p.rdmdt[k];
-    	  a[k]=p.a[k];
-    	  atree[k]=p.atree[k];
+        rdmdt[k]=p.rdmdt[k];
+        a[k]=p.a[k];
+        atree[k]=p.atree[k];
       }
       for (int ivar=0; ivar<ndim+2; ivar++) {
-    	  dQ[ivar]=p.dQ[ivar];
-    	  dQdt[ivar]=p.dQdt[ivar];
+        dQ[ivar]=p.dQ[ivar];
+        dQdt[ivar]=p.dQdt[ivar];
       }
       iorig = p.iorig;
       gpot = p.gpot;
@@ -248,22 +248,22 @@ public:
   typedef MeshlessForcesParticle ReturnDataType;
 
   void ReceiveParticleAccelerations (const ReturnDataType* pointer, MeshlessFVParticle<ndim>& p2) {
-	    const ReturnDataType& p = *pointer;
+    const ReturnDataType& p = *pointer;
 
-	    for (int k=0; k<ndim; k++) {
-	      p2.rdmdt[k] += p.rdmdt[k];
-	      p2.a[k] += p.a[k];
-	      p2.atree[k] += p.atree[k];
-	    }
+    for (int k=0; k<ndim; k++) {
+      p2.rdmdt[k] += p.rdmdt[k];
+      p2.a[k] += p.a[k];
+      p2.atree[k] += p.atree[k];
+    }
 
-	    for (int ivar=0; ivar<ndim+2; ivar++) {
-	    	  p2.dQ[ivar]+=p.dQ[ivar];
-	    	  p2.dQdt[ivar]+=p.dQdt[ivar];
-	    }
+    for (int ivar=0; ivar<ndim+2; ivar++) {
+      p2.dQ[ivar]+=p.dQ[ivar];
+      p2.dQdt[ivar]+=p.dQdt[ivar];
+    }
 
-	    p2.gpot += p.gpot;
-      p2.gpot_hydro += p.gpot_hydro;
-	    p2.vsig_max = max(p2.vsig_max,p.vsig_max);
+    p2.gpot += p.gpot;
+    p2.gpot_hydro += p.gpot_hydro;
+    p2.vsig_max = max(p2.vsig_max,p.vsig_max);
   }
 
   void ReceiveParticle (const void* pointer, MeshlessFVParticle<ndim>& p2, Hydrodynamics<ndim>* hydro) {
@@ -279,34 +279,34 @@ public:
       p2.v[k]=p.v[k];
       p2.a[k]=0.0;
       p2.atree[k]=0;
-	  for (int kk=0; kk<ndim; kk++) {
-			p2.B[k][kk]=p.B[k][kk];
-	  }
-	  p2.rdmdt[k]=0.0;
-  }
+      for (int kk=0; kk<ndim; kk++) {
+        p2.B[k][kk]=p.B[k][kk];
+      }
+      p2.rdmdt[k]=0.0;
+    }
 
-	for (int ivar=0; ivar<ndim+2; ivar++) {
-		p2.Wprim[ivar]=p.Wprim[ivar];
-		p2.alpha_slope[ivar]=p.alpha_slope[ivar];
-		for (int k=0; k<ndim; k++) {
-			p2.grad[ivar][k] = p.grad[ivar][k];
-		}
-		p2.dQ[ivar]=0.0;
-		p2.dQdt[ivar]=0.0;
-}
+    for (int ivar=0; ivar<ndim+2; ivar++) {
+      p2.Wprim[ivar]=p.Wprim[ivar];
+      p2.alpha_slope[ivar]=p.alpha_slope[ivar];
+      for (int k=0; k<ndim; k++) {
+        p2.grad[ivar][k] = p.grad[ivar][k];
+      }
+      p2.dQ[ivar]=0.0;
+      p2.dQdt[ivar]=0.0;
+    }
 
-  p2.m = p.m;
-  p2.ndens = p.ndens;
-  p2.gpot = 0.0;
-  p2.gpot_hydro = 0.0;
-  p2.vsig_max=p.vsig_max;
-  p2.sound=p.sound;
+    p2.m = p.m;
+    p2.ndens = p.ndens;
+    p2.gpot = 0.0;
+    p2.gpot_hydro = 0.0;
+    p2.vsig_max=p.vsig_max;
+    p2.sound=p.sound;
 
-  //Recompute h dependent stuff
-  p2.rho = p2.ndens*p2.m;
-  p2.h = hydro->h_fac*pow(1/p2.ndens, (FLOAT)(1.)/ndim);
-  p2.hfactor = pow(1/p2.h, ndim+1);
-  p2.hrangesqd = hydro->kernrange*hydro->kernrange*p2.h*p2.h;
+    //Recompute h dependent stuff
+    p2.rho = p2.ndens*p2.m;
+    p2.h = hydro->h_fac*pow(1/p2.ndens, (FLOAT)(1.)/ndim);
+    p2.hfactor = pow(1/p2.h, ndim+1);
+    p2.hrangesqd = hydro->kernrange*hydro->kernrange*p2.h*p2.h;
   }
 
 };
@@ -368,11 +368,11 @@ class TreeCommunicationHandler {
 
     TreeCellStreamlined (const TreeCellBase<ndim>& c, int Nactive, int exported_particles) {
 
-        ifirst = exported_particles;
-        ilast = exported_particles+Nactive-1;
-        N = Nactive;
-        amin = c.amin;
-      }
+      ifirst = exported_particles;
+      ilast = exported_particles+Nactive-1;
+      N = Nactive;
+      amin = c.amin;
+    }
 
 
     FLOAT amin ;
@@ -380,7 +380,7 @@ class TreeCommunicationHandler {
     int ilast;
     int N;
 
-    };
+  };
 
 public:
 
@@ -435,7 +435,7 @@ public:
       c.hmax = max(c.hmax,p.h);
       c.maxsound = max(c.maxsound,p.sound);
       c.amin = min(c.amin,
-                   sqrt(DotProduct(partdata[i].atree,partdata[i].atree,ndim)));
+          sqrt(DotProduct(partdata[i].atree,partdata[i].atree,ndim)));
     }
 
     FLOAT dr[ndim];

--- a/src/Headers/FV.h
+++ b/src/Headers/FV.h
@@ -38,7 +38,6 @@
 #include "Parameters.h"
 #include "Particle.h"
 #include "Precision.h"
-#include "RiemannSolver.h"
 #include "SlopeLimiter.h"
 #include "SmoothingKernel.h"
 #if defined _OPENMP
@@ -86,10 +85,6 @@ public:
   static const int ietot = ndim + 1;
   static const int ipress = ndim + 1;
 
-  const FLOAT eta_eos;                           ///< Polytropic index
-  const FLOAT gamma_eos;                         ///< gamma, ratio of specific heats
-  const FLOAT gammam1;                           ///< gamma - 1
-
 
   // Constructor
   //-----------------------------------------------------------------------------------------------
@@ -106,11 +101,8 @@ public:
 
   // Other functions
   //-----------------------------------------------------------------------------------------------
-  void CalculateFluxVectorFromPrimitive(const FLOAT Wprim[nvar], FLOAT flux[nvar][ndim]);
-  void CalculatePrimitiveTimeDerivative(const FLOAT Wprim[nvar], const FLOAT gradW[nvar][ndim], FLOAT Wdot[nvar]);
-  void ConvertConservedToPrimitive(const FLOAT, const FLOAT Qcons[nvar], FLOAT Wprim[nvar]);
-  void ConvertPrimitiveToConserved(const FLOAT, const FLOAT Wprim[nvar], FLOAT Qcons[nvar]);
-
+  void CalculatePrimitiveTimeDerivative(const FLOAT Wprim[nvar], const FLOAT gradW[nvar][ndim],
+                                        const FLOAT c_s, FLOAT Wdot[nvar]);
 
 };
 #endif

--- a/src/Headers/Hydrodynamics.h
+++ b/src/Headers/Hydrodynamics.h
@@ -36,7 +36,6 @@
 #include "Parameters.h"
 #include "DomainBox.h"
 #include "EOS.h"
-#include "RiemannSolver.h"
 #include "ExternalPotential.h"
 #include "SimUnits.h"
 #if defined _OPENMP

--- a/src/Headers/Integration.h
+++ b/src/Headers/Integration.h
@@ -77,7 +77,7 @@ class SphIntegration : public TimeIntegration<ndim>
 
   //SphIntegration(DOUBLE accel_mult_aux, DOUBLE courant_mult_aux):
   //  accel_mult(accel_mult_aux),courant_mult(courant_mult_aux) {}
-  SphIntegration(DOUBLE, DOUBLE, DOUBLE, eosenum, tdaviscenum);
+  SphIntegration(DOUBLE, DOUBLE, DOUBLE, bool, tdaviscenum);
   virtual ~SphIntegration();
 
   void SetActiveParticles(const int, Hydrodynamics<ndim> *) = 0 ;
@@ -91,7 +91,7 @@ class SphIntegration : public TimeIntegration<ndim>
   const DOUBLE accel_mult ;
   const DOUBLE courant_mult ;
   const DOUBLE energy_mult ;
-  const eosenum gas_eos ;
+  const bool energy_integration ;
   const tdaviscenum tdavisc;
 };
 
@@ -110,11 +110,11 @@ class SphLeapfrogKDK: public SphIntegration<ndim>
 {
  public:
 
-  using SphIntegration<ndim>::gas_eos;
+  using SphIntegration<ndim>::energy_integration;
   using SphIntegration<ndim>::tdavisc;
   using SphIntegration<ndim>::timing;
 
-  SphLeapfrogKDK(DOUBLE, DOUBLE, DOUBLE, eosenum, tdaviscenum);
+  SphLeapfrogKDK(DOUBLE, DOUBLE, DOUBLE, bool, tdaviscenum);
   virtual ~SphLeapfrogKDK();
 
   void SetActiveParticles(const int, Hydrodynamics<ndim> *);
@@ -141,11 +141,11 @@ class SphLeapfrogDKD: public SphIntegration<ndim>
 {
  public:
 
-  using SphIntegration<ndim>::gas_eos;
+  using SphIntegration<ndim>::energy_integration;
   using SphIntegration<ndim>::tdavisc;
   using SphIntegration<ndim>::timing;
 
-  SphLeapfrogDKD(DOUBLE, DOUBLE, DOUBLE, eosenum, tdaviscenum);
+  SphLeapfrogDKD(DOUBLE, DOUBLE, DOUBLE, bool, tdaviscenum);
   virtual  ~SphLeapfrogDKD();
 
   void SetActiveParticles(const int, Hydrodynamics<ndim> *);

--- a/src/Headers/MeshlessFV.h
+++ b/src/Headers/MeshlessFV.h
@@ -82,8 +82,6 @@ public:
   using Hydrodynamics<ndim>::self_gravity;
   using Hydrodynamics<ndim>::size_hydro_part;
   using Hydrodynamics<ndim>::types;
-  using FV<ndim>::gamma_eos;
-  using FV<ndim>::gammam1;
 
   static const int nvar = ndim + 2;
   static const int ivx = 0;
@@ -191,8 +189,6 @@ class MfvCommon : public MeshlessFV<ndim>
  public:
 
   using MeshlessFV<ndim>::allocated;
-  using MeshlessFV<ndim>::gamma_eos;
-  using MeshlessFV<ndim>::gammam1;
   using MeshlessFV<ndim>::h_converge;
   using MeshlessFV<ndim>::h_fac;
   using MeshlessFV<ndim>::hydrodata;
@@ -275,8 +271,6 @@ class MfvMuscl : public MfvCommon<ndim,kernelclass,SlopeLimiterType>
   using Hydrodynamics<ndim>::create_sinks;
   using Hydrodynamics<ndim>::hmin_sink;
   using MeshlessFV<ndim>::allocated;
-  using MeshlessFV<ndim>::gamma_eos;
-  using MeshlessFV<ndim>::gammam1;
   using MeshlessFV<ndim>::h_converge;
   using MeshlessFV<ndim>::h_fac;
   using MeshlessFV<ndim>::hydrodata;
@@ -351,8 +345,6 @@ class MfvRungeKutta : public MfvCommon<ndim,kernelclass,SlopeLimiterType>
   using Hydrodynamics<ndim>::create_sinks;
   using Hydrodynamics<ndim>::hmin_sink;
   using MeshlessFV<ndim>::allocated;
-  using MeshlessFV<ndim>::gamma_eos;
-  using MeshlessFV<ndim>::gammam1;
   using MeshlessFV<ndim>::h_converge;
   using MeshlessFV<ndim>::h_fac;
   using MeshlessFV<ndim>::hydrodata;
@@ -418,7 +410,7 @@ inline void MeshlessFV<ndim>::UpdatePrimitiveVector(MeshlessFVParticle<ndim> &pa
 {
   for (int k=0; k<ndim; k++) part.Wprim[k] = part.v[k];
   part.Wprim[irho] = part.rho;
-  part.Wprim[ipress] = part.press;
+  part.Wprim[ipress] = part.pressure;
 }
 
 

--- a/src/Headers/OpacityTable.h
+++ b/src/Headers/OpacityTable.h
@@ -23,8 +23,9 @@
 #ifndef _OPACITY_TABLE_H_
 #define _OPACITY_TABLE_H_
 
-#include "Particle.h"
 #include "SimUnits.h"
+
+template<int> class EosParticleProxy;
 
 //=================================================================================================
 //  Class OpacityTable
@@ -49,9 +50,10 @@ class OpacityTable
   int GetIEner(const FLOAT, const int);
   void GetKappa(const int, const int, FLOAT &, FLOAT &, FLOAT &);
   FLOAT GetEnergy(const int, const int);
-  FLOAT GetMuBar(Particle<ndim> &part);
-  FLOAT GetGamma(Particle<ndim> &part);
-  FLOAT GetGamma1(Particle<ndim> &part);
+  FLOAT GetMuBar(const EosParticleProxy<ndim> &part);
+  FLOAT GetGamma(const EosParticleProxy<ndim> &part);
+  FLOAT GetGamma1(const EosParticleProxy<ndim> &part);
+  FLOAT GetEnergyFromPressure(const FLOAT, const FLOAT);
   //-----------------------------------------------------------------------------------------------
 
   int ndens;

--- a/src/Headers/OpacityTable.h
+++ b/src/Headers/OpacityTable.h
@@ -41,7 +41,7 @@ class OpacityTable
 {
  public:
 
-  OpacityTable(string, SimUnits *);
+  OpacityTable(Parameters*, SimUnits *);
   ~OpacityTable();
 
   int GetIDens(const FLOAT);

--- a/src/Headers/Particle.h
+++ b/src/Headers/Particle.h
@@ -155,6 +155,7 @@ struct Particle
   FLOAT hfactor;                    ///< invh^(ndim + 1)
   FLOAT sound;                      ///< Sound speed
   FLOAT rho;                        ///< Density
+  FLOAT pressure;                   ///< Pressure
   FLOAT u;                          ///< Specific internal energy
   FLOAT u0;                         ///< u at beginning of step
   FLOAT dudt0;                      ///< dudt at beginning of step
@@ -195,6 +196,7 @@ struct Particle
     hrangesqd = (FLOAT) 0.0;
     hfactor   = (FLOAT) 0.0;
     rho       = (FLOAT) 0.0;
+    pressure  = (FLOAT) 0.0;
     sound     = (FLOAT) 0.0;
     u         = (FLOAT) 0.0;
     u0        = (FLOAT) 0.0;
@@ -230,7 +232,6 @@ struct SphParticle : public Particle<ndim>
   using Particle<ndim>::r ;
   using Particle<ndim>::v ;
 
-  FLOAT pressure;                   ///< Pressure
   FLOAT div_v;                      ///< Velocity divergence
   FLOAT alpha;                      ///< Artificial viscosity alpha value
   FLOAT dalphadt;                   ///< Rate of change of alpha
@@ -238,7 +239,6 @@ struct SphParticle : public Particle<ndim>
 
   SphParticle()
   {
-    pressure = (FLOAT) 0.0;
     div_v    = (FLOAT) 0.0;
     alpha    = (FLOAT) 0.0;
     dalphadt = (FLOAT) 0.0;
@@ -329,7 +329,7 @@ struct GradhSphParticle : public SphParticle<ndim>
 		  hrangesqd=p.hrangesqd;
 		  hfactor=p.hfactor;
 		  pressure=p.pressure;
-      invomega=p.invomega;
+		  invomega=p.invomega;
 		  sound=p.sound;
 		  u=p.u;
 		  alpha=p.alpha;
@@ -350,7 +350,7 @@ struct GradhSphParticle : public SphParticle<ndim>
 	  FLOAT hrangesqd;
 	  FLOAT hfactor;
 	  FLOAT pressure;
-    FLOAT invomega;
+      FLOAT invomega;
 	  FLOAT sound;
 	  FLOAT u;
 	  FLOAT alpha;
@@ -414,7 +414,6 @@ struct MeshlessFVParticle : public Particle<ndim>
   using Particle<ndim>::v;
   using Particle<ndim>::a;
 
-  FLOAT press;                         ///< Pressure
   FLOAT invomega;                      ///< ..
   FLOAT div_v;                         ///< Velocity divergence
   FLOAT ndens;                         ///< Particle number density, inverse volume
@@ -434,7 +433,6 @@ struct MeshlessFVParticle : public Particle<ndim>
   MeshlessFVParticle()
   {
     invomega  = (FLOAT) 1.0;
-    press     = (FLOAT) 0.0;
     div_v     = (FLOAT) 0.0;
     ndens     = (FLOAT) 0.0;
     zeta      = (FLOAT) 0.0;
@@ -505,7 +503,7 @@ struct MeshlessFVParticle : public Particle<ndim>
   class FluxParticle {
   public:
 	  FluxParticle (): ptype(gas_type), flags(none), level(0), iorig(0), r(), v(), a(), Wprim(), dQ(),
-	  dQdt(), rdmdt(), h(0), hrangesqd(0), ndens(0), hfactor(0) {
+	  dQdt(), rdmdt(), h(0), hrangesqd(0), ndens(0), hfactor(0), sound(0) {
 		  for (int k=0; k<ndim; k++)
 			  for (int kk=0; kk<ndim; kk++)
 				  B[k][kk]=0;
@@ -537,6 +535,7 @@ struct MeshlessFVParticle : public Particle<ndim>
 		  hrangesqd=p.hrangesqd;
 		  ndens=p.ndens;
 		  hfactor=p.hfactor;
+		  sound=p.sound;
 	  }
 
 	  int ptype;
@@ -557,7 +556,7 @@ struct MeshlessFVParticle : public Particle<ndim>
 	  FLOAT hrangesqd;
 	  FLOAT ndens;
 	  FLOAT hfactor;
-
+	  FLOAT sound;
 
 	  static const int NDIM=ndim;
 

--- a/src/Headers/Sph.h
+++ b/src/Headers/Sph.h
@@ -39,7 +39,6 @@
 #include "NeighbourManager.h"
 #include "Parameters.h"
 #include "Precision.h"
-#include "RiemannSolver.h"
 #include "SimUnits.h"
 #include "SmoothingKernel.h"
 #if defined _OPENMP

--- a/src/Hydrodynamics/Hydrodynamics.cpp
+++ b/src/Hydrodynamics/Hydrodynamics.cpp
@@ -109,7 +109,7 @@ Hydrodynamics<ndim>::Hydrodynamics(int hydro_forces_aux, int self_gravity_aux, F
   else if (_gas_eos == "barotropic2") {
     eos = new Barotropic2<ndim>(params, &units);
   }
-  else if (_gas_eos == "rad_ws" || _gas_eos == "radws") {
+  else if ( _gas_eos == "radws") {
     eos = new Radws<ndim>(params, &units);
   }
   else {

--- a/src/Hydrodynamics/SphIntegration.cpp
+++ b/src/Hydrodynamics/SphIntegration.cpp
@@ -48,12 +48,12 @@ SphIntegration<ndim>::SphIntegration
 (DOUBLE accel_mult_aux,             ///< Copy of accel timestep multiplier
  DOUBLE courant_mult_aux,           ///< Copy of Courant timestep multipiler
  DOUBLE energy_mult_aux,            ///< Copy of Energy timestep multipiler
- eosenum gas_eos_aux,
+ bool energy_integration_aux,
  tdaviscenum tdavisc_aux) :
   accel_mult(accel_mult_aux),
   courant_mult(courant_mult_aux),
   energy_mult(energy_mult_aux),
-  gas_eos(gas_eos_aux),
+  energy_integration(energy_integration_aux),
   tdavisc(tdavisc_aux)
 {
 }
@@ -114,7 +114,7 @@ DOUBLE SphIntegration<ndim>::Timestep
 
 
   // Explicit energy integration timestep condition
-  if (gas_eos == energy_eqn && part.ptype == gas_type) {
+  if (energy_integration && part.ptype == gas_type) {
     timestep = min(timestep, this->energy_mult*(DOUBLE) (part.u/(fabs(part.dudt) + small_number)));
   }
 

--- a/src/Hydrodynamics/SphLeapfrogDKD.cpp
+++ b/src/Hydrodynamics/SphLeapfrogDKD.cpp
@@ -44,9 +44,10 @@ using namespace std;
 //=================================================================================================
 template <int ndim, template <int> class ParticleType>
 SphLeapfrogDKD<ndim, ParticleType>::SphLeapfrogDKD(DOUBLE accel_mult_aux, DOUBLE courant_mult_aux,
-                                                   DOUBLE energy_mult_aux, eosenum gas_eos_aux,
+                                                   DOUBLE energy_mult_aux, bool energy_integration,
                                                    tdaviscenum tdavisc_aux) :
-  SphIntegration<ndim>(accel_mult_aux, courant_mult_aux, energy_mult_aux, gas_eos_aux, tdavisc_aux)
+  SphIntegration<ndim>(accel_mult_aux, courant_mult_aux, energy_mult_aux, energy_integration,
+                       tdavisc_aux)
 {
 }
 
@@ -119,7 +120,7 @@ void SphLeapfrogDKD<ndim, ParticleType>::AdvanceParticles
     if (tdavisc != notdav) part.alpha += part.dalphadt*timestep;
 
     // Integrate explicit energy equation
-    if (gas_eos == energy_eqn) part.u = part.u0 + part.dudt*dt;
+    if (energy_integration) part.u = part.u0 + part.dudt*dt;
 
     // Set particle as active at end of step
     if (dn == nstep/2) part.flags.set(active);
@@ -195,7 +196,7 @@ void SphLeapfrogDKD<ndim, ParticleType>::EndTimestep
       for (k=0; k<ndim; k++) part.v0[k] = part.v[k];
       for (k=0; k<ndim; k++) part.a0[k] = part.a[k];
 
-      if (gas_eos == energy_eqn) {
+      if (energy_integration) {
         part.u0 = part.u;
       }
 

--- a/src/Hydrodynamics/SphLeapfrogKDK.cpp
+++ b/src/Hydrodynamics/SphLeapfrogKDK.cpp
@@ -45,8 +45,8 @@ using namespace std;
 template <int ndim, template <int> class ParticleType>
 SphLeapfrogKDK<ndim, ParticleType>::SphLeapfrogKDK
  (DOUBLE _accel_mult, DOUBLE _courant_mult, DOUBLE _energy_mult,
-  eosenum _gas_eos, tdaviscenum _tdavisc) :
-  SphIntegration<ndim>(_accel_mult, _courant_mult, _energy_mult, _gas_eos, _tdavisc)
+  bool _energy_integration, tdaviscenum _tdavisc) :
+  SphIntegration<ndim>(_accel_mult, _courant_mult, _energy_mult, _energy_integration, _tdavisc)
 {
 }
 
@@ -111,7 +111,7 @@ void SphLeapfrogKDK<ndim, ParticleType >::AdvanceParticles
     if (tdavisc != notdav) part.alpha += part.dalphadt*timestep;
 
     // Integrate explicit energy equation
-    if (gas_eos == energy_eqn) part.u = part.u0 + part.dudt0*dt;
+    if (energy_integration) part.u = part.u0 + part.dudt0*dt;
 
     // Set particle as active at end of step
     if (dn == nstep) part.flags.set(active);
@@ -165,7 +165,7 @@ void SphLeapfrogKDK<ndim, ParticleType>::CorrectionTerms
     if (dn == nstep) {
       for (k=0; k<ndim; k++) part.v[k] += 0.5 * part.dt * (part.a[k] - part.a0[k]);
 
-      if (gas_eos == energy_eqn) {
+      if (energy_integration) {
         part.u     += 0.5*(part.dudt - part.dudt0) * part.dt; //timestep*(FLOAT) nstep;
 
         // In spurious cases where correction term can lead to negative energies, simply use
@@ -245,7 +245,7 @@ void SphLeapfrogKDK<ndim, ParticleType>::EndTimestep
       for (k=0; k<ndim; k++) part.a0[k] = part.a[k];
 
       // If using an adiabatic energy equation, then explictly integrate the internal energy
-      if (gas_eos == energy_eqn) {
+      if (energy_integration) {
         part.u     += 0.5*(part.dudt - part.dudt0) * part.dt; //timestep*(FLOAT) nstep;
 
         // In spurious cases where correction term can lead to negative energies, simply use

--- a/src/MeshlessFV/MeshlessFV.cpp
+++ b/src/MeshlessFV/MeshlessFV.cpp
@@ -155,11 +155,11 @@ void MeshlessFV<ndim>::ComputeThermalProperties
 
   part.u     = eos->SpecificInternalEnergy(part);
   part.sound = eos->SoundSpeed(part);
-  part.press = eos->Pressure(part);
+  part.pressure = eos->Pressure(part);
 
   assert(part.u > (FLOAT) 0.0);
   assert(part.sound > (FLOAT) 0.0);
-  assert(part.press > (FLOAT) 0.0);
+  assert(part.pressure > (FLOAT) 0.0);
 
   return;
 }
@@ -186,15 +186,6 @@ void MeshlessFV<ndim>::UpdateArrayVariables(MeshlessFVParticle<ndim> &part, FLOA
     for (int k=0; k<ndim; k++) ekin += part.v[k]*part.v[k];
 
     part.u = (Qcons[ietot] - (FLOAT) 0.5*part.m*ekin)/part.m;
-    part.u = eos->SpecificInternalEnergy(part);
-    part.press = (gamma_eos - (FLOAT) 1.0)*part.rho*part.u;
-
-    if (part.u < 0)
-      cout << part.iorig << " " << part.ptype << ", " << part.u << " "
-        << Qcons[ietot] << " " << ekin << "\n";
-
-    assert(part.u > 0);
-    assert(part.press > 0);
   }
 
   return;

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -598,6 +598,7 @@ void MeshlessFVSimulation<ndim>::PostInitialConditionsSetup(void)
       part.nstep  = 0;
       part.nlast  = 0;
       part.tlast  = t;
+      part.dt     = 0;
       part.flags.set(active);
     }
     for (i=0; i<mfv->Nhydro; i++) mfv->GetMeshlessFVParticlePointer(i).flags.set(active);

--- a/src/MeshlessFV/MfvMuscl.cpp
+++ b/src/MeshlessFV/MfvMuscl.cpp
@@ -142,8 +142,14 @@ void MfvMuscl<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
     for (k=0; k<ndim; k++)
       Aij[k] = volume_i*psitildaj[k] - volume_j*psitildai[k];
 
-    FLOAT Amag = sqrt(DotProduct(Aij, Aij, ndim) + small_number);
-    for (k=0; k<ndim; k++) Aunit[k] = Aij[k] / Amag;
+    FLOAT Amag = sqrt(DotProduct(Aij, Aij, ndim));
+    if (Amag > 0) {
+      for (k=0; k<ndim; k++) Aunit[k] = Aij[k] / Amag;
+    } else {
+      // Skip pair as there is no face area to pass flux across.
+      continue ;
+    }
+
 
     // Calculate position and velocity of the face
     if (staticParticles) {
@@ -162,7 +168,7 @@ void MfvMuscl<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
     for (k=0; k<ndim; k++) Wi[k] -= vface[k];
 
     // Time-integrate LHS state to half-timestep value
-    this->CalculatePrimitiveTimeDerivative(Wi, gradW, Wdot);
+    this->CalculatePrimitiveTimeDerivative(Wi, gradW, part.sound, Wdot);
     for (k=0; k<ndim; k++) Wdot[k] += part.a[k];
     for (var=0; var<nvar; var++) Wi[var] += (FLOAT) 0.5*Wdot[var]*dt;
 
@@ -173,7 +179,7 @@ void MfvMuscl<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
     for (k=0; k<ndim; k++) Wj[k] -= vface[k];
 
     // Time-integrate RHS state to half-timestep value
-    this->CalculatePrimitiveTimeDerivative(Wj, gradW, Wdot);
+    this->CalculatePrimitiveTimeDerivative(Wj, gradW, neibpart[j].sound, Wdot);
     for (k=0; k<ndim; k++) Wdot[k] += neibpart[j].a[k];
     for (var=0; var<nvar; var++) Wj[var] += (FLOAT) 0.5*Wdot[var]*dt;
 
@@ -193,7 +199,29 @@ void MfvMuscl<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
       riemannExact.ComputeFluxes(Wi, Wj, Aunit, vface, flux);
     }
     else {
-      riemannHLLC.ComputeFluxes(Wi, Wj, Aunit, vface, flux);
+      // Compute both the primitive and conserved quantities so the HLLC solver doesn't
+      // have to make assumptions about the EOS.
+      EosParticleProxy<ndim> Pi, Pj;
+      for (int k=0; k <ndim; k++) {
+        Pi.r[k] = Pj.r[k] = rface[k];
+        Pi.v[k] = Wi[k];
+        Pj.v[k] = Wj[k];
+      }
+      Pi.rho = Wi[irho];
+      Pj.rho = Wj[irho];
+      Pi.p = Wi[ipress];
+      Pj.p = Wj[ipress];
+
+      // Convert primitive to conserved and construct state object
+      Pi.u = this->eos->InternalEnergyFromPressure(Pi);
+      Pj.u = this->eos->InternalEnergyFromPressure(Pj);
+
+      StateVector<ndim> Si, Sj;
+      this->eos->ConstructStateVector(Pi, Si);
+      this->eos->ConstructStateVector(Pj, Sj);
+
+      //riemannHLLC.ComputeFluxes(Wi, Wj, Aunit, vface, flux);
+      riemannHLLC.ComputeFluxes(Si, Sj, Aunit, vface, flux);
     }
 
     // Add the viscosity

--- a/src/MeshlessFV/MfvRungeKutta.cpp
+++ b/src/MeshlessFV/MfvRungeKutta.cpp
@@ -179,12 +179,12 @@ void MfvRungeKutta<ndim, kernelclass,SlopeLimiter>::ComputeGodunovFlux
     }
 
     // Time-integrate LHS state to half-timestep value
-    this->CalculatePrimitiveTimeDerivative(Wleft, gradW, Wdot);
+    this->CalculatePrimitiveTimeDerivative(Wleft, gradW, part.sound, Wdot);
     for (k=0; k<ndim; k++) Wdot[k] += part.a[k];
     for (var=0; var<nvar; var++) Wleft[var] += (FLOAT) Wdot[var]*dt;
 
     // Time-integrate RHS state to half-timestep value
-    this->CalculatePrimitiveTimeDerivative(Wright, gradW, Wdot);
+    this->CalculatePrimitiveTimeDerivative(Wright, gradW, neibpart[j].sound, Wdot);
     for (k=0; k<ndim; k++) Wdot[k] += neibpart[j].a[k];
     for (var=0; var<nvar; var++) Wright[var] += (FLOAT) Wdot[var]*dt;
 

--- a/src/Thermal/AdiabaticEOS.cpp
+++ b/src/Thermal/AdiabaticEOS.cpp
@@ -70,6 +70,12 @@ FLOAT Adiabatic<ndim>::SoundSpeed(Particle<ndim> &part)
 {
   return sqrt(gamma*gammam1*part.u);
 }
+template <int ndim>
+FLOAT Adiabatic<ndim>::SoundSpeed(FLOAT, FLOAT u)
+{
+  return sqrt(gamma*gammam1*u);
+}
+
 
 
 

--- a/src/Thermal/AdiabaticEOS.cpp
+++ b/src/Thermal/AdiabaticEOS.cpp
@@ -33,7 +33,7 @@
 //=================================================================================================
 template <int ndim>
 Adiabatic<ndim>::Adiabatic(Parameters* simparams, SimUnits *units):
-  EOS<ndim>(simparams->floatparams["gamma_eos"], simparams->floatparams["gamma_eos"]),
+  EOS<ndim>(simparams->floatparams["gamma_eos"]),
   mu_bar(simparams->floatparams["mu_bar"])
 {
 }
@@ -54,7 +54,7 @@ Adiabatic<ndim>::~Adiabatic()
 /// Calculates and returns value of Entropic function (= P/rho^gamma) for referenced particle
 //=================================================================================================
 template <int ndim>
-FLOAT Adiabatic<ndim>::EntropicFunction(Particle<ndim> &part)
+FLOAT Adiabatic<ndim>::EntropicFunction(const EosParticleProxy<ndim>&part)
 {
   return gammam1*part.u*pow(part.rho,(FLOAT) 1.0 - gamma);
 }
@@ -66,16 +66,10 @@ FLOAT Adiabatic<ndim>::EntropicFunction(Particle<ndim> &part)
 /// Returns adiabatic sound speed of particle
 //=================================================================================================
 template <int ndim>
-FLOAT Adiabatic<ndim>::SoundSpeed(Particle<ndim> &part)
+FLOAT Adiabatic<ndim>::SoundSpeed(const EosParticleProxy<ndim>&part)
 {
   return sqrt(gamma*gammam1*part.u);
 }
-template <int ndim>
-FLOAT Adiabatic<ndim>::SoundSpeed(FLOAT, FLOAT u)
-{
-  return sqrt(gamma*gammam1*u);
-}
-
 
 
 
@@ -84,7 +78,7 @@ FLOAT Adiabatic<ndim>::SoundSpeed(FLOAT, FLOAT u)
 /// Returns specific internal energy of particle
 //=================================================================================================
 template <int ndim>
-FLOAT Adiabatic<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
+FLOAT Adiabatic<ndim>::SpecificInternalEnergy(const EosParticleProxy<ndim>&part)
 {
   return part.u;
 }
@@ -96,7 +90,7 @@ FLOAT Adiabatic<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
 /// Returns temperature of particle
 //=================================================================================================
 template <int ndim>
-FLOAT Adiabatic<ndim>::Temperature(Particle<ndim> &part)
+FLOAT Adiabatic<ndim>::Temperature(const EosParticleProxy<ndim>&part)
 {
   return gammam1*part.u;
 }

--- a/src/Thermal/Barotropic2EOS.cpp
+++ b/src/Thermal/Barotropic2EOS.cpp
@@ -78,6 +78,12 @@ FLOAT Barotropic2<ndim>::SoundSpeed(Particle<ndim> &part)
 {
   return sqrt(gammam1*part.u);
 }
+template <int ndim>
+FLOAT Barotropic2<ndim>::SoundSpeed(FLOAT, FLOAT u)
+{
+  return sqrt(gammam1*u);
+}
+
 
 
 

--- a/src/Thermal/Barotropic2EOS.cpp
+++ b/src/Thermal/Barotropic2EOS.cpp
@@ -37,7 +37,7 @@
 //=================================================================================================
 template <int ndim>
 Barotropic2<ndim>::Barotropic2(Parameters* simparams, SimUnits *units):
-  EOS<ndim>(simparams->floatparams["gamma_eos"], simparams->floatparams["gamma_eos"])
+  EOS<ndim>(simparams->floatparams["gamma_eos"])
 {
   temp0    = simparams->floatparams["temp0"]/units->temp.outscale;
   mu_bar   = simparams->floatparams["mu_bar"];
@@ -62,7 +62,7 @@ Barotropic2<ndim>::~Barotropic2()
 /// Calculates and returns value of Entropic function (= P/rho^gamma) for referenced particle.
 //=================================================================================================
 template <int ndim>
-FLOAT Barotropic2<ndim>::EntropicFunction(Particle<ndim> &part)
+FLOAT Barotropic2<ndim>::EntropicFunction(const EosParticleProxy<ndim>&part)
 {
   return gammam1*part.u*pow(part.rho,(FLOAT) 1.0 - gamma);
 }
@@ -74,16 +74,10 @@ FLOAT Barotropic2<ndim>::EntropicFunction(Particle<ndim> &part)
 /// Returns isothermal sound speed of SPH particle
 //=================================================================================================
 template <int ndim>
-FLOAT Barotropic2<ndim>::SoundSpeed(Particle<ndim> &part)
+FLOAT Barotropic2<ndim>::SoundSpeed(const EosParticleProxy<ndim>&part)
 {
   return sqrt(gammam1*part.u);
 }
-template <int ndim>
-FLOAT Barotropic2<ndim>::SoundSpeed(FLOAT, FLOAT u)
-{
-  return sqrt(gammam1*u);
-}
-
 
 
 
@@ -92,7 +86,7 @@ FLOAT Barotropic2<ndim>::SoundSpeed(FLOAT, FLOAT u)
 /// Returns specific internal energy
 //=================================================================================================
 template <int ndim>
-FLOAT Barotropic2<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
+FLOAT Barotropic2<ndim>::SpecificInternalEnergy(const EosParticleProxy<ndim>&part)
 {
   if (part.rho < rho_bary) return temp0/gammam1/mu_bar;
   else return temp0*pow(part.rho*invrho_bary,gammam1)/gammam1/mu_bar;
@@ -107,7 +101,7 @@ FLOAT Barotropic2<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
 /// adiabatic phase (T = const*rho^{gamma - 1} for rho > rho_bary).
 //=================================================================================================
 template <int ndim>
-FLOAT Barotropic2<ndim>::Temperature(Particle<ndim> &part)
+FLOAT Barotropic2<ndim>::Temperature(const EosParticleProxy<ndim>&part)
 {
   if (part.rho < rho_bary) return temp0;
   else return temp0*pow(part.rho*invrho_bary,gammam1);

--- a/src/Thermal/BarotropicEOS.cpp
+++ b/src/Thermal/BarotropicEOS.cpp
@@ -77,6 +77,13 @@ FLOAT Barotropic<ndim>::SoundSpeed(Particle<ndim> &part)
 {
   return sqrt(gammam1*part.u);
 }
+template <int ndim>
+FLOAT Barotropic<ndim>::SoundSpeed(FLOAT, FLOAT u)
+{
+  return sqrt(gammam1*u);
+}
+
+
 
 
 

--- a/src/Thermal/BarotropicEOS.cpp
+++ b/src/Thermal/BarotropicEOS.cpp
@@ -35,7 +35,7 @@
 //=================================================================================================
 template <int ndim>
 Barotropic<ndim>::Barotropic(Parameters* simparams, SimUnits *units):
-  EOS<ndim>(simparams->floatparams["gamma_eos"], simparams->floatparams["gamma_eos"])
+  EOS<ndim>(simparams->floatparams["gamma_eos"])
 {
   temp0    = simparams->floatparams["temp0"]/units->temp.outscale;
   mu_bar   = simparams->floatparams["mu_bar"];
@@ -61,7 +61,7 @@ Barotropic<ndim>::~Barotropic()
 /// Calculates and returns value of Entropic function (= P/rho^gamma) for referenced particle.
 //=================================================================================================
 template <int ndim>
-FLOAT Barotropic<ndim>::EntropicFunction(Particle<ndim> &part)
+FLOAT Barotropic<ndim>::EntropicFunction(const EosParticleProxy<ndim>&part)
 {
   return gammam1*part.u*pow(part.rho,(FLOAT) 1.0 - gamma);
 }
@@ -73,17 +73,10 @@ FLOAT Barotropic<ndim>::EntropicFunction(Particle<ndim> &part)
 /// Returns sound speed of SPH particle
 //=================================================================================================
 template <int ndim>
-FLOAT Barotropic<ndim>::SoundSpeed(Particle<ndim> &part)
+FLOAT Barotropic<ndim>::SoundSpeed(const EosParticleProxy<ndim>&part)
 {
   return sqrt(gammam1*part.u);
 }
-template <int ndim>
-FLOAT Barotropic<ndim>::SoundSpeed(FLOAT, FLOAT u)
-{
-  return sqrt(gammam1*u);
-}
-
-
 
 
 
@@ -92,7 +85,7 @@ FLOAT Barotropic<ndim>::SoundSpeed(FLOAT, FLOAT u)
 /// Returns specific internal energy
 //=================================================================================================
 template <int ndim>
-FLOAT Barotropic<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
+FLOAT Barotropic<ndim>::SpecificInternalEnergy(const EosParticleProxy<ndim>&part)
 {
   return temp0*(1.0 + pow(part.rho*invrho_bary,gammam1))/gammam1/mu_bar;
 }
@@ -106,7 +99,7 @@ FLOAT Barotropic<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
 /// adiabatic phase (T = const*rho^{gamma - 1} for rho >> rho_bary).
 //=================================================================================================
 template <int ndim>
-FLOAT Barotropic<ndim>::Temperature(Particle<ndim> &part)
+FLOAT Barotropic<ndim>::Temperature(const EosParticleProxy<ndim>&part)
 {
   return temp0*(1.0 + pow(part.rho*invrho_bary,gammam1));
 }

--- a/src/Thermal/DiscLocallyIsothermal.cpp
+++ b/src/Thermal/DiscLocallyIsothermal.cpp
@@ -64,7 +64,7 @@ DiscLocallyIsothermal<ndim>::~DiscLocallyIsothermal()
 /// Set the sound speed given distance to the star
 //=================================================================================================
 template <int ndim>
-FLOAT DiscLocallyIsothermal<ndim>::SoundSpeed(Particle<ndim> & part)
+FLOAT DiscLocallyIsothermal<ndim>::SoundSpeed(const EosParticleProxy<ndim>& part)
 {
   StarParticle<ndim>* star = nbody->stardata;
 
@@ -84,17 +84,11 @@ FLOAT DiscLocallyIsothermal<ndim>::SoundSpeed(Particle<ndim> & part)
 /// Set the internal energy given the position of the particle
 //=================================================================================================
 template <int ndim>
-FLOAT DiscLocallyIsothermal<ndim>::SpecificInternalEnergy(Particle<ndim> & part)
+FLOAT DiscLocallyIsothermal<ndim>::SpecificInternalEnergy(const EosParticleProxy<ndim>& part)
 {
   FLOAT cs = SoundSpeed(part);
   return cs*cs/gammam1;
 }
-template <int ndim>
-FLOAT DiscLocallyIsothermal<ndim>::InternalEnergy(FLOAT, FLOAT u)
-{
-  return sqrt(gammam1*u);
-}
-
 
 
 //=================================================================================================
@@ -102,7 +96,7 @@ FLOAT DiscLocallyIsothermal<ndim>::InternalEnergy(FLOAT, FLOAT u)
 /// Set the temperature given the position of the particle
 //=================================================================================================
 template <int ndim>
-FLOAT DiscLocallyIsothermal<ndim>::Temperature(Particle<ndim> & part)
+FLOAT DiscLocallyIsothermal<ndim>::Temperature(const EosParticleProxy<ndim>& part)
 {
   FLOAT cs = SoundSpeed(part);
   return mu_bar*cs*cs;

--- a/src/Thermal/DiscLocallyIsothermal.cpp
+++ b/src/Thermal/DiscLocallyIsothermal.cpp
@@ -89,6 +89,12 @@ FLOAT DiscLocallyIsothermal<ndim>::SpecificInternalEnergy(Particle<ndim> & part)
   FLOAT cs = SoundSpeed(part);
   return cs*cs/gammam1;
 }
+template <int ndim>
+FLOAT DiscLocallyIsothermal<ndim>::InternalEnergy(FLOAT, FLOAT u)
+{
+  return sqrt(gammam1*u);
+}
+
 
 
 //=================================================================================================

--- a/src/Thermal/EOS.cpp
+++ b/src/Thermal/EOS.cpp
@@ -1,0 +1,72 @@
+//=================================================================================================
+//  EOS.cpp
+//  Contains function definitions for the base Equation of state.
+//
+//  This file is part of GANDALF :
+//  Graphical Astrophysics code for N-body Dynamics And Lagrangian Fluids
+//  https://github.com/gandalfcode/gandalf
+//  Contact : gandalfcode@gmail.com
+//
+//  Copyright (C) 2013  D. A. Hubber, G. Rosotti, R. Booth
+//
+//  GANDALF is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  GANDALF is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License (http://www.gnu.org/licenses) for more details.
+//=================================================================================================
+
+#include "EOS.h"
+
+//=================================================================================================
+//  EOS::PrimitiveToConserved()
+/// Convert primitive variables to conserved quantities
+//=================================================================================================
+template<int ndim>
+void EOS<ndim>::PrimitiveToConserved
+(const PrimitiveVariables<ndim>& Wprim,       ///< [in]  Primitive variables
+ ConservedVariables<ndim>& Ucons)             ///< [out] Conserved variables
+{
+  Ucons.density = Wprim.density;
+
+  FLOAT Ek = 0;
+  for (int i=0; i<ndim; ++i) {
+    Ucons.momentum[i] = Wprim.density * Wprim.velocity[i];
+    Ek += 0.5 *  Wprim.density * Wprim.velocity[i] * Wprim.velocity[i];
+  }
+
+  Ucons.energy = Ek + Wprim.density * this->InternalEnergy(Wprim.density, Wprim.pressure);
+}
+
+
+//=================================================================================================
+//  EOS::ConservedToPrimitive()
+/// Convert conserved quantities to primitive variables
+//=================================================================================================
+template<int ndim>
+void EOS<ndim>::ConservedToPrimitive
+(const ConservedVariables<ndim>& Ucons,       ///< [in]  Conserved variables
+ PrimitiveVariables<ndim>& Wprim)             ///< [out] Primitive variables
+{
+  Wprim.density = Ucons.density;
+
+  FLOAT Ek = 0;
+  for (int i=0; i<ndim; ++i) {
+    Wprim.velocity[i] = Ucons.momentum[i] / Ucons.density ;
+    Ek += 0.5 *   Ucons.momentum[i] * Ucons.momentum[i] / Ucons.density;
+  }
+
+  Wprim.pressure =  this->Pressure(Ucons.density, (Ucons.energy-Ek) / Wprim.density);
+}
+
+
+template class EOS<1>;
+template class EOS<2>;
+template class EOS<3>;
+
+
+

--- a/src/Thermal/IonisingRadiationEOS.cpp
+++ b/src/Thermal/IonisingRadiationEOS.cpp
@@ -33,7 +33,7 @@
 //=================================================================================================
 template <int ndim>
 IonisingRadiation<ndim>::IonisingRadiation(Parameters* simparams, SimUnits *units):
- EOS<ndim>(simparams->floatparams["gamma_eos"], simparams->floatparams["gamma_eos"]),
+ EOS<ndim>(simparams->floatparams["gamma_eos"]),
  temp0(simparams->floatparams["temp0"]/units->temp.outscale),
  mu_bar(simparams->floatparams["mu_bar"])
 {
@@ -72,7 +72,7 @@ IonisingRadiation<ndim>::~IonisingRadiation()
 /// Calculates and returns value of Entropic function (= P/rho^gamma) for referenced particle
 //=================================================================================================
 template <int ndim>
-FLOAT IonisingRadiation<ndim>::EntropicFunction(Particle<ndim> &part)
+FLOAT IonisingRadiation<ndim>::EntropicFunction(const EosParticleProxy<ndim>&part)
 {
   //return gammam1*part.u*pow(part.rho,(FLOAT) 1.0 - gamma);
   return eos->EntropicFunction(part);
@@ -85,17 +85,11 @@ FLOAT IonisingRadiation<ndim>::EntropicFunction(Particle<ndim> &part)
 /// Returns isothermal sound speed of SPH particle
 //=================================================================================================
 template <int ndim>
-FLOAT IonisingRadiation<ndim>::SoundSpeed(Particle<ndim> &part)
+FLOAT IonisingRadiation<ndim>::SoundSpeed(const EosParticleProxy<ndim>&part)
 {
   //return sqrt(gammam1*part.u);
   return eos->SoundSpeed(part);
 }
-template <int ndim>
-FLOAT IonisingRadiation<ndim>::SoundSpeed(FLOAT rho, FLOAT u)
-{
-  return eos->SoundSpeed(rho, u);
-}
-
 
 
 //=================================================================================================
@@ -103,7 +97,7 @@ FLOAT IonisingRadiation<ndim>::SoundSpeed(FLOAT rho, FLOAT u)
 /// Returns specific internal energy
 //=================================================================================================
 template <int ndim>
-FLOAT IonisingRadiation<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
+FLOAT IonisingRadiation<ndim>::SpecificInternalEnergy(const EosParticleProxy<ndim>&part)
 {
   // Checks if particle's internal energy has been changed by the ionisation routine
   // If it has it compares this new internal energy to that of the EOS and chooses the largest.
@@ -122,7 +116,7 @@ FLOAT IonisingRadiation<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
 /// Returns temperature of particle.
 //=================================================================================================
 template <int ndim>
-FLOAT IonisingRadiation<ndim>::Temperature(Particle<ndim> &part)
+FLOAT IonisingRadiation<ndim>::Temperature(const EosParticleProxy<ndim>&part)
 {
   return eos->Temperature(part);
 }

--- a/src/Thermal/IonisingRadiationEOS.cpp
+++ b/src/Thermal/IonisingRadiationEOS.cpp
@@ -90,6 +90,11 @@ FLOAT IonisingRadiation<ndim>::SoundSpeed(Particle<ndim> &part)
   //return sqrt(gammam1*part.u);
   return eos->SoundSpeed(part);
 }
+template <int ndim>
+FLOAT IonisingRadiation<ndim>::SoundSpeed(FLOAT rho, FLOAT u)
+{
+  return eos->SoundSpeed(rho, u);
+}
 
 
 

--- a/src/Thermal/IsothermalEOS.cpp
+++ b/src/Thermal/IsothermalEOS.cpp
@@ -33,7 +33,7 @@
 //=================================================================================================
 template <int ndim>
 Isothermal<ndim>::Isothermal(Parameters* simparams, SimUnits *units):
-  EOS<ndim>(1, simparams->floatparams["gamma_eos"]),
+  EOS<ndim>(simparams->floatparams["gamma_eos"]),
   temp0(simparams->floatparams["temp0"]/units->temp.outscale),
   mu_bar(simparams->floatparams["mu_bar"])
 {
@@ -57,7 +57,7 @@ Isothermal<ndim>::~Isothermal()
 /// Calculates and returns value of Entropic function (= P/rho^gamma) for referenced particle
 //=================================================================================================
 template <int ndim>
-FLOAT Isothermal<ndim>::EntropicFunction(Particle<ndim> &part)
+FLOAT Isothermal<ndim>::EntropicFunction(const EosParticleProxy<ndim>&part)
 {
   return gammam1*part.u*pow(part.rho,(FLOAT) 1.0 - gamma);
 }
@@ -69,7 +69,7 @@ FLOAT Isothermal<ndim>::EntropicFunction(Particle<ndim> &part)
 /// Returns isothermal sound speed of referenced SPH particle
 //=================================================================================================
 template <int ndim>
-FLOAT Isothermal<ndim>::SoundSpeed(Particle<ndim> &part)
+FLOAT Isothermal<ndim>::SoundSpeed(const EosParticleProxy<ndim>&part)
 {
   return sqrt(gammam1*part.u);
 }
@@ -81,7 +81,7 @@ FLOAT Isothermal<ndim>::SoundSpeed(Particle<ndim> &part)
 /// Returns specific internal energy of referenced SPH particle
 //=================================================================================================
 template <int ndim>
-FLOAT Isothermal<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
+FLOAT Isothermal<ndim>::SpecificInternalEnergy(const EosParticleProxy<ndim>&part)
 {
   return temp0/gammam1/mu_bar;
 }
@@ -93,7 +93,7 @@ FLOAT Isothermal<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
 /// Return isothermal temperature, temp0, for referenced SPH particle
 //=================================================================================================
 template <int ndim>
-FLOAT Isothermal<ndim>::Temperature(Particle<ndim> &part)
+FLOAT Isothermal<ndim>::Temperature(const EosParticleProxy<ndim>&part)
 {
   return temp0;
 }

--- a/src/Thermal/LocallyIsothermal.cpp
+++ b/src/Thermal/LocallyIsothermal.cpp
@@ -64,7 +64,7 @@ LocallyIsothermal<ndim>::~LocallyIsothermal()
 /// Set the temperature given distance to nearest star
 //=================================================================================================
 template <int ndim>
-FLOAT LocallyIsothermal<ndim>::Temperature(Particle<ndim> & part)
+FLOAT LocallyIsothermal<ndim>::Temperature(const EosParticleProxy<ndim>& part)
 {
   FLOAT stardistmin=1e30;
   StarParticle<ndim>* star = nbody->stardata;
@@ -89,7 +89,7 @@ FLOAT LocallyIsothermal<ndim>::Temperature(Particle<ndim> & part)
 /// Set the internal energt given distance to nearest star
 //=================================================================================================
 template <int ndim>
-FLOAT LocallyIsothermal<ndim>::SpecificInternalEnergy(Particle<ndim> & part)
+FLOAT LocallyIsothermal<ndim>::SpecificInternalEnergy(const EosParticleProxy<ndim>& part)
 {
   FLOAT temp = LocallyIsothermal<ndim>::Temperature(part);
   return temp/gammam1/mu_bar;

--- a/src/Thermal/MCRadiationEOS.cpp
+++ b/src/Thermal/MCRadiationEOS.cpp
@@ -76,7 +76,7 @@ MCRadiationEOS<ndim>::~MCRadiationEOS()
 /// Calculates and returns value of Entropic function (= P/rho^gamma) for referenced particle
 //=================================================================================================
 template <int ndim>
-FLOAT MCRadiationEOS<ndim>::EntropicFunction(Particle<ndim> &part)
+FLOAT MCRadiationEOS<ndim>::EntropicFunction(const EosParticleProxy<ndim>&part)
 {
   //return gammam1*part.u*pow(part.rho,(FLOAT) 1.0 - gamma);
   return eos->EntropicFunction(part);
@@ -89,7 +89,7 @@ FLOAT MCRadiationEOS<ndim>::EntropicFunction(Particle<ndim> &part)
 /// Returns isothermal sound speed of SPH particle
 //=================================================================================================
 template <int ndim>
-FLOAT MCRadiationEOS<ndim>::SoundSpeed(Particle<ndim> &part)
+FLOAT MCRadiationEOS<ndim>::SoundSpeed(const EosParticleProxy<ndim>&part)
 {
   //return sqrt(gammam1*part.u);
   return part.ionfrac*sqrt(temp_ion/mu_ion) + (1.0 - part.ionfrac)*eos->SoundSpeed(part);
@@ -102,7 +102,7 @@ FLOAT MCRadiationEOS<ndim>::SoundSpeed(Particle<ndim> &part)
 /// Returns specific internal energy
 //=================================================================================================
 template <int ndim>
-FLOAT MCRadiationEOS<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
+FLOAT MCRadiationEOS<ndim>::SpecificInternalEnergy(const EosParticleProxy<ndim>&part)
 {
   //cout << "u : " << part.ionfrac << "  " << temp_ion << "   " << gammam1 << "   " << mu_ion << "  "
   //   << (1.0 - part.ionfrac) << "   " <<  eos->SpecificInternalEnergy(part) << endl;
@@ -117,7 +117,7 @@ FLOAT MCRadiationEOS<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
 /// Returns temperature of particle.
 //=================================================================================================
 template <int ndim>
-FLOAT MCRadiationEOS<ndim>::Temperature(Particle<ndim> &part)
+FLOAT MCRadiationEOS<ndim>::Temperature(const EosParticleProxy<ndim>&part)
 {
   return part.ionfrac*temp_ion + (1.0 - part.ionfrac)*eos->Temperature(part);
 }

--- a/src/Thermal/PolytropicEOS.cpp
+++ b/src/Thermal/PolytropicEOS.cpp
@@ -32,7 +32,8 @@
 //=================================================================================================
 template <int ndim>
 Polytropic<ndim>::Polytropic(Parameters* simparams, SimUnits *units):
-  EOS<ndim>(simparams->floatparams["eta_eos"], simparams->floatparams["gamma_eos"]),
+  EOS<ndim>(simparams->floatparams["eta_eos"]),
+  eta(simparams->floatparams["gamma_eos"]),
   Kpoly(simparams->floatparams["Kpoly"])
 {
 }
@@ -55,7 +56,7 @@ Polytropic<ndim>::~Polytropic()
 /// Calculates and returns thermal pressure of referenced particle
 //=================================================================================================
 template <int ndim>
-FLOAT Polytropic<ndim>::Pressure(Particle<ndim> &part)
+FLOAT Polytropic<ndim>::Pressure(const EosParticleProxy<ndim>&part)
 {
   return Kpoly*pow(part.rho, eta);
 }
@@ -67,7 +68,7 @@ FLOAT Polytropic<ndim>::Pressure(Particle<ndim> &part)
 /// Calculates and returns value of Entropic function (= P/rho^gamma) for referenced particle
 //=================================================================================================
 template <int ndim>
-FLOAT Polytropic<ndim>::EntropicFunction(Particle<ndim> &part)
+FLOAT Polytropic<ndim>::EntropicFunction(const EosParticleProxy<ndim>&part)
 {
   return gammam1*part.u*pow(part.rho,(FLOAT) 1.0 - gamma);
 }
@@ -79,7 +80,7 @@ FLOAT Polytropic<ndim>::EntropicFunction(Particle<ndim> &part)
 /// Returns Polytropic sound speed of referenced SPH particle
 //=================================================================================================
 template <int ndim>
-FLOAT Polytropic<ndim>::SoundSpeed(Particle<ndim> &part)
+FLOAT Polytropic<ndim>::SoundSpeed(const EosParticleProxy<ndim>&part)
 {
   return sqrt(gammam1*part.u);
 }
@@ -91,7 +92,7 @@ FLOAT Polytropic<ndim>::SoundSpeed(Particle<ndim> &part)
 /// Returns specific internal energy of referenced SPH particle
 //=================================================================================================
 template <int ndim>
-FLOAT Polytropic<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
+FLOAT Polytropic<ndim>::SpecificInternalEnergy(const EosParticleProxy<ndim>&part)
 {
   return Kpoly*pow(part.rho, gammam1)/gammam1;
 }
@@ -103,7 +104,7 @@ FLOAT Polytropic<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
 /// Return Polytropic temperature, temp0, for referenced SPH particle
 //=================================================================================================
 template <int ndim>
-FLOAT Polytropic<ndim>::Temperature(Particle<ndim> &part)
+FLOAT Polytropic<ndim>::Temperature(const EosParticleProxy<ndim>&part)
 {
   return gammam1*part.u;
 }

--- a/src/Thermal/RadwsEOS.cpp
+++ b/src/Thermal/RadwsEOS.cpp
@@ -55,7 +55,7 @@ Radws<ndim>::~Radws()
 /// Returns pressure of a particle based on a variable gamma
 //=================================================================================================
 template <int ndim>
-FLOAT Radws<ndim>::Pressure(Particle<ndim> &part)
+FLOAT Radws<ndim>::Pressure(const EosParticleProxy<ndim>&part)
 {
   FLOAT gamma = opacity_table->GetGamma(part);
   return (gamma - 1.0) * part.rho * part.u;
@@ -69,7 +69,7 @@ FLOAT Radws<ndim>::Pressure(Particle<ndim> &part)
 /// referenced particle
 //=================================================================================================
 template <int ndim>
-FLOAT Radws<ndim>::EntropicFunction(Particle<ndim> &part)
+FLOAT Radws<ndim>::EntropicFunction(const EosParticleProxy<ndim>&part)
 {
   FLOAT gamma = opacity_table->GetGamma(part);
   return (gamma - 1.0)*part.u*pow(part.rho, (FLOAT) (1.0 - gamma));
@@ -82,22 +82,12 @@ FLOAT Radws<ndim>::EntropicFunction(Particle<ndim> &part)
 /// Returns adiabatic sound speed of particle
 //=================================================================================================
 template <int ndim>
-FLOAT Radws<ndim>::SoundSpeed(Particle<ndim> &part)
+FLOAT Radws<ndim>::SoundSpeed(const EosParticleProxy<ndim>&part)
 {
   FLOAT gamma = opacity_table->GetGamma(part);
   FLOAT gamma1 = opacity_table->GetGamma1(part);
   return sqrt(gamma1*(gamma - 1.0)*part.u);
 }
-//=================================================================================================
-//  Radws::SoundSpeed
-/// Returns adiabatic sound speed of particle
-//=================================================================================================
-template <int ndim>
-FLOAT Radws<ndim>::SoundSpeed(FLOAT, FLOAT u)
-{
-  return sqrt(gamma*gammam1*u);
-}
-
 
 
 
@@ -106,7 +96,7 @@ FLOAT Radws<ndim>::SoundSpeed(FLOAT, FLOAT u)
 /// Returns specific internal energy of particle
 //=================================================================================================
 template <int ndim>
-FLOAT Radws<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
+FLOAT Radws<ndim>::SpecificInternalEnergy(const EosParticleProxy<ndim>&part)
 {
   return part.u;
 }
@@ -118,13 +108,21 @@ FLOAT Radws<ndim>::SpecificInternalEnergy(Particle<ndim> &part)
 /// Returns temperature of particle
 //=================================================================================================
 template <int ndim>
-FLOAT Radws<ndim>::Temperature(Particle<ndim> &part)
+FLOAT Radws<ndim>::Temperature(const EosParticleProxy<ndim>&part)
 {
   FLOAT gamma = opacity_table->GetGamma(part);
   FLOAT mu_bar = opacity_table->GetMuBar(part);
   return (gamma - 1.0)*part.u*mu_bar;
 }
 
+//=================================================================================================
+//  Radws::InternalEnergyFromPressure
+/// Invert pressure to get internal energy
+//==============================================================================================
+template <int ndim>
+FLOAT Radws<ndim>::InternalEnergyFromPressure(const EosParticleProxy<ndim>&p){
+  return opacity_table->GetEnergyFromPressure(p.rho, p.p);
+}
 
 
 template class Radws<1>;

--- a/src/Thermal/RadwsEOS.cpp
+++ b/src/Thermal/RadwsEOS.cpp
@@ -35,7 +35,7 @@ template <int ndim>
 Radws<ndim>::Radws(Parameters* simparams, SimUnits *units) :
   EOS<ndim>(simparams->floatparams["gamma_eos"])
 {
-  opacity_table = new OpacityTable<ndim>(simparams->stringparams["radws_table"], units);
+  opacity_table = new OpacityTable<ndim>(simparams, units);
 }
 
 

--- a/src/Thermal/RadwsEOS.cpp
+++ b/src/Thermal/RadwsEOS.cpp
@@ -88,6 +88,16 @@ FLOAT Radws<ndim>::SoundSpeed(Particle<ndim> &part)
   FLOAT gamma1 = opacity_table->GetGamma1(part);
   return sqrt(gamma1*(gamma - 1.0)*part.u);
 }
+//=================================================================================================
+//  Radws::SoundSpeed
+/// Returns adiabatic sound speed of particle
+//=================================================================================================
+template <int ndim>
+FLOAT Radws<ndim>::SoundSpeed(FLOAT, FLOAT u)
+{
+  return sqrt(gamma*gammam1*u);
+}
+
 
 
 

--- a/tests/gravhydro_tests/radws_test.dat
+++ b/tests/gravhydro_tests/radws_test.dat
@@ -46,7 +46,7 @@ Diagnostic output frequency                 : ndiagstep = 32
 #------------------------
 Hydro force calculate                       : hydro_forces = 1
 Gas equation of state                       : gas_eos = radws
-Energy integration                          : energy_integration = rad_ws
+Energy integration                          : energy_integration = radws
 EOS look-up file                            : radws_table = ../../eos.bell.cc.dat
 Ambient temperature                         : temp_ambient = 10.0
 

--- a/tests/hydro_tests/radwsshocktest.py
+++ b/tests/hydro_tests/radwsshocktest.py
@@ -1,0 +1,45 @@
+from gandalf.analysis.facade import *
+import numpy as np
+import matplotlib.pyplot as plt
+
+def run_test(sim, **params):
+    sim = newsim(paramfile="sod_radws.dat", sim=sim)
+    for k, p in params.items():
+        sim.SetParam(k, p)
+
+    run_async().wait()
+    snap(-1)
+    
+    x   = get_data('x')
+    rho = get_data('rho')
+
+    # Re-scale the density to get sensible error-norm estimates
+    rho /= sim.simparams.floatparams['rhofluid1']
+        
+    return x, rho
+
+def interpolate(x1, y1, x2):
+    args = np.argsort(x1)
+    return np.interp(x2, x1[args], y1[args], period=4.)
+
+
+
+x_SPH, rho_SPH = run_test('sph')
+x_MFM, rho_MFM = run_test('mfvmuscl')
+x_AD , rho_AD  = run_test('sph', gas_eos='energy_eqn')
+
+xi = np.linspace(-2, 2, 10**4)
+
+l, = plt.plot(x_SPH, rho_SPH, '.', label='SPH')
+plt.plot(xi, interpolate(x_SPH, rho_SPH, xi), '--', c=l.get_color())
+
+l, = plt.plot(x_MFM, rho_MFM, '.', label='MFM')
+plt.plot(xi, interpolate(x_MFM, rho_MFM, xi), '--', c=l.get_color())
+
+l, = plt.plot(x_AD, rho_AD, 'k.', label='ideal gas, SPH')
+plt.plot(xi, interpolate(x_AD, rho_AD, xi), '--', c=l.get_color())
+
+
+
+plt.legend(loc='best')
+plt.show()

--- a/tests/hydro_tests/sod_radws.dat
+++ b/tests/hydro_tests/sod_radws.dat
@@ -1,0 +1,98 @@
+#----------------------------------------
+# Adiabatic Sod shock tube test
+# Creates an adiabatic Sod shocktube test
+#----------------------------------------
+
+
+#-----------------------------
+# Initial conditions variables
+#-----------------------------
+Simulation run id string                    : run_id = SOD_RADWS
+Select SPH simulation                       : sim = gradhsph
+Select shocktube initial conditions         : ic = shocktube
+1D shocktube test                           : ndim = 1
+x-velocity of LHS fluid                     : vfluid1[0] = 0.0
+x-velocity of RHS fluid                     : vfluid2[0] = 0.0
+Pressure of LHS fluid                       : press1 = 1.0e-10
+Pressure of RHS fluid                       : press2 = 1.975e-11
+Density of LHS fluid                        : rhofluid1 = 1.0e-16
+Density of RHS fluid                        : rhofluid2 = 2.5e-17
+No. of particles in LHS fluid               : Nlattice1[0] = 512
+No. of particles in RHS fluid               : Nlattice2[0] = 128
+
+#---------------------------
+# Simulation units variables
+#---------------------------
+Use physical units                          : dimensionless = 0
+Length units 				    : routunit = au
+Velocity units				    : voutunit = km_s
+Time units				    : toutunit = yr
+Density units				    : rhooutunit = kg_m3
+Pressure units				    : pressoutunit = Pa
+
+#------------------------------
+# Simulation boundary variables
+#------------------------------
+LHS position of boundary in x-dimension     : boxmin[0] = -2.0
+RHS position of boundary in x-dimension     : boxmax[0] = 2.0
+LHS boundary type in x-dimension            : boundary_lhs[0] = periodic
+RHS boundary type in x-dimension            : boundary_rhs[0] = periodic
+
+
+#--------------------------
+# Simulation time variables
+#--------------------------
+Simulation end time                         : tend = 2.0
+Regular snapshot output frequency           : dt_snap = 1.0
+Time for first snapshot                     : tsnapfirst = 0.0
+Screen output frequency (in no. of steps)   : noutputstep = 32
+Output file format                          : out_file_form = su
+
+
+#------------------------
+# Thermal physics options
+#------------------------
+Switch-on hydrodynamical forces             : hydro_forces = 1
+Main gas thermal physics treatment          : gas_eos = radws
+     	 	 	 		    : energy_integration = null
+					    : radws_table = ../../eos.bell.cc.dat
+					    : gamma_eos = 1.6666666666666666666667
+
+#----------------------------------------
+# Smoothed Particle Hydrodynamics options
+#----------------------------------------
+SPH smoothing kernel choice                 : kernel = m4
+SPH smoothing length iteration tolerance    : h_converge = 0.01
+
+
+#---------------------------------
+# SPH artificial viscosity options
+#---------------------------------
+Artificial viscosity choice                 : avisc = mon97
+Artificial conductivity choice              : acond = none
+Artificial viscosity alpha value            : alpha_visc = 1.0
+Artificial viscosity beta value             : beta_visc = 2.0
+
+
+#-------------------------
+# Time integration options
+#-------------------------
+SPH particle integration option             : sph_integration = lfkdk
+SPH Courant timestep condition multiplier   : courant_mult = 0.2
+SPH acceleration condition multiplier       : accel_mult = 0.4
+SPH energy equation timestep multiplier     : energy_mult = 0.5
+No. of block timestep levels                : Nlevels = 1
+
+
+#---------------------
+# Optimisation options
+#---------------------
+Tabulate SPH kernel                         : tabulated_kernel = 0
+SPH neighbour search algorithm              : neib_search = bruteforce
+Build tree every step                       : ntreebuildstep = 1
+Stock tree every step                       : ntreestockstep = 1
+
+#--------------
+# Misc. options
+#--------------
+Switch-off self-gravity of gas              : self_gravity = 0

--- a/tests/hydro_tests/test_radws_shock.py
+++ b/tests/hydro_tests/test_radws_shock.py
@@ -1,0 +1,42 @@
+from gandalf.analysis.facade import *
+import numpy as np
+import unittest
+
+## For this test there is no analytical solution, so we will just compare
+## the meshless to SPH...
+class RadWS_Shock(unittest.TestCase):
+    def setUp(self):
+        self.expected_l1error_1 = 3e-3
+        self.expected_l1error_2 = 3e-3
+
+
+    def run_test(self, sim, params={}):
+        sim = newsim(paramfile="tests/hydro_tests/sod_radws.dat", sim=sim)
+        sim.SetParam('radws_table', 'eos.bell.cc.dat')
+        for k, p in params.items():
+            sim.SetParam(k, p)
+
+        run_async().wait()
+        snap(-1)
+
+        x   = get_data('x')
+        rho = get_data('rho')
+
+        # Re-scale the density to get sensible error-norm estimates
+        rho /= sim.simparams.floatparams['rhofluid1']
+        
+        return x, rho
+
+    def interpolate(self, x1, y1, x2):
+        args = np.argsort(x1)
+        return np.interp(x2, x1[args], y1[args], period=4.)
+
+    def test_error(self):
+        x_sph, rho_sph = self.run_test('sph')
+        x_mfm, rho_mfm = self.run_test('mfvmuscl')
+
+        L1_1 = abs(self.interpolate(x_sph, rho_sph, x_mfm) - rho_mfm).mean()
+        L1_2 = abs(self.interpolate(x_mfm, rho_mfm, x_sph) - rho_sph).mean()
+
+        self.assertLess(L1_1, self.expected_l1error_1)
+        self.assertLess(L1_2, self.expected_l1error_2)


### PR DESCRIPTION
This pull request includes changes that refactor the meshless to work with an arbitrary equation of state. 

I've tested this this will the EOS that includes H2 dissociation and H + He ionization from Stamatellos+ (2007), which makes up  the 'EOS' part of the radws scheme. I've also included an extra shock test to check that this is working. Since there are no analytical solutions I just compare the SPH and meshless results. Given that we already test the EOS itself with the cloud collapse test, I think this should be satisfactory.