### PR TITLE
Meshless gravity fix

### DIFF
--- a/src/Headers/CommunicationHandler.h
+++ b/src/Headers/CommunicationHandler.h
@@ -406,7 +406,6 @@ public:
     c.m = 0;
     c.hmax = 0;
     c.maxsound = 0;
-    c.amin = big_number;
     for (int k=0; k<ndim; k++) {
       c.bb.min[k] = big_number;
       c.bb.max[k] = -big_number;

--- a/src/Headers/CommunicationHandler.h
+++ b/src/Headers/CommunicationHandler.h
@@ -433,8 +433,6 @@ public:
       c.m += p.m;
       c.hmax = max(c.hmax,p.h);
       c.maxsound = max(c.maxsound,p.sound);
-      c.amin = min(c.amin,
-                   sqrt(DotProduct(partdata[i].atree,partdata[i].atree,ndim)));
     }
 
     FLOAT dr[ndim];

--- a/src/MeshlessFV/MeshlessFVSimulation.cpp
+++ b/src/MeshlessFV/MeshlessFVSimulation.cpp
@@ -571,6 +571,23 @@ void MeshlessFVSimulation<ndim>::PostInitialConditionsSetup(void)
   nbody->LoadStellarPropertiesTable(&simunits);
   nbody->UpdateStellarProperties();
 
+  for (i=0; i<mfv->Ntot; i++) {
+    MeshlessFVParticle<ndim>& part = mfv->GetMeshlessFVParticlePointer(i);
+    for (k=0; k<ndim; k++) {
+      part.a[k] = (FLOAT) 0.0;
+      part.atree[k] = (FLOAT) 0.0;
+      part.rdmdt[k] = 0.0;
+      part.rdmdt0[k] = 0.0;
+    }
+    for (k=0; k<ndim+2; k++) part.dQ[k] = (FLOAT) 0.0;
+    for (k=0; k<ndim+2; k++) part.dQdt[k] = (FLOAT) 0.0;
+    part.level  = 0;
+    part.nstep  = 0;
+    part.nlast  = 0;
+    part.tlast  = t;
+    part.dt     = 0;
+    part.flags.set(active);
+  }
 
   // Compute all initial hydro terms
   // We will need to iterate if we are going to use a relative opening criterion
@@ -583,24 +600,6 @@ void MeshlessFVSimulation<ndim>::PostInitialConditionsSetup(void)
       mfvneib->SetOpeningCriterion(geometric);
     else
       mfvneib->SetOpeningCriterion(mac_type) ;
-
-    for (i=0; i<mfv->Ntot; i++) {
-      MeshlessFVParticle<ndim>& part = mfv->GetMeshlessFVParticlePointer(i);
-      for (k=0; k<ndim; k++) {
-        part.a[k] = (FLOAT) 0.0;
-        part.atree[k] = (FLOAT) 0.0;
-        part.rdmdt[k] = 0.0;
-        part.rdmdt0[k] = 0.0;
-      }
-      for (k=0; k<ndim+2; k++) part.dQ[k] = (FLOAT) 0.0;
-      for (k=0; k<ndim+2; k++) part.dQdt[k] = (FLOAT) 0.0;
-      part.level  = 0;
-      part.nstep  = 0;
-      part.nlast  = 0;
-      part.tlast  = t;
-      part.flags.set(active);
-    }
-    for (i=0; i<mfv->Nhydro; i++) mfv->GetMeshlessFVParticlePointer(i).flags.set(active);
 
     // Copy all other data from real hydro particles to ghosts
     LocalGhosts->CopyHydroDataToGhosts(simbox,mfv);
@@ -634,7 +633,6 @@ void MeshlessFVSimulation<ndim>::PostInitialConditionsSetup(void)
     }
 
     if (mfv->self_gravity == 1 || nbody->Nnbody > 0) {
-
       mfv->ZeroAccelerations();
 
 #ifdef MPI_PARALLEL


### PR DESCRIPTION
This pull request fixes some errors relating to the meshless and self-gravity with the gadget mac. Before these changes atree was being zero'd in the initializaiton resulting in a brute-force gravity calculation. 

There was also a mistake for the imported cells, which has been fixed: we were trying to recompute the acceleration tolerance, amin, for imported cells, which does not work because atree is zerod.