### PR TITLE
Improve ics2

### DIFF
--- a/src/Headers/Ic.h
+++ b/src/Headers/Ic.h
@@ -584,7 +584,7 @@ public:
   virtual ~GreshoVortexIc() {};
 
   virtual void Generate(void);
-  virtual FLOAT GetValue(const std::string, const FLOAT *);
+  virtual FLOAT GetDensity(const FLOAT *, const int) const;
 
 };
 
@@ -788,7 +788,6 @@ public:
   virtual ~PolytropeIc();
 
   virtual void Generate(void);
-  virtual FLOAT GetValue(const std::string, const FLOAT *);
   static void ComputeIsothermalLaneEmdenSolution(const int, const FLOAT, FLOAT *, FLOAT *, FLOAT *, FLOAT *);
   static void ComputeLaneEmdenSolution(const int, const FLOAT, const FLOAT, FLOAT *, FLOAT *, FLOAT *, FLOAT *);
 

--- a/src/Ic/BossBodenheimerIc.cpp
+++ b/src/Ic/BossBodenheimerIc.cpp
@@ -162,8 +162,8 @@ void BossBodenheimerIc<ndim>::Generate(void)
 
 
 //=================================================================================================
-//  BossBodenheimer::GetValue
-/// Returns the value of the requested quantity at the given position.
+//  BossBodenheimer::GetDensity
+/// Returns the density at the given position.
 //=================================================================================================
 template <int ndim>
 FLOAT BossBodenheimerIc<ndim>::GetDensity

--- a/src/Ic/GreshoVortexIc.cpp
+++ b/src/Ic/GreshoVortexIc.cpp
@@ -31,8 +31,8 @@ using namespace std;
 
 
 //=================================================================================================
-//  Khi::Khi
-/// Set-up Khi-type simulation initial conditions.
+//  GreshoVortexIc::GreshoVortexIc
+/// Constructor for generating Gresho-Chan vortex initial conditions.
 //=================================================================================================
 template <int ndim>
 GreshoVortexIc<ndim>::GreshoVortexIc(Simulation<ndim>* _sim, FLOAT _invndim) :
@@ -50,8 +50,8 @@ GreshoVortexIc<ndim>::GreshoVortexIc(Simulation<ndim>* _sim, FLOAT _invndim) :
 
 
 //=================================================================================================
-//  Khi::Generate
-/// Set-up Khi-type simulation initial conditions.
+//  GreshoVortexIc::Generate
+/// Generate all particles for Gresho-Chan vortex simulation initial conditions.
 //=================================================================================================
 template <int ndim>
 void GreshoVortexIc<ndim>::Generate(void)
@@ -131,30 +131,15 @@ void GreshoVortexIc<ndim>::Generate(void)
 
 
 //=================================================================================================
-//  GreshoVortexIc::GetValue
+//  GreshoVortexIc::GetDensity
 /// Returns the value of the requested quantity at the given position.
 //=================================================================================================
 template <int ndim>
-FLOAT GreshoVortexIc<ndim>::GetValue
- (const std::string var,
-  const FLOAT r[ndim])
+FLOAT GreshoVortexIc<ndim>::GetDensity
+ (const FLOAT r[ndim],
+  const int ptype) const
 {
-  if (var == "x") {
-    return r[0];
-  }
-  else if (ndim > 1 && var == "y") {
-    return r[1];
-  }
-  else if (ndim > 2 && var == "z") {
-    return r[2];
-  }
-  else if (var == "rho") {
-    return (FLOAT) 1.0;
-  }
-  else {
-    std::cout << "Invalid string variable for GreshoVortexIc::GetValue" << std::endl;
-    return 0.0;
-  }
+  return (FLOAT) 1.0;
 }
 
 

--- a/src/Ic/Ic.cpp
+++ b/src/Ic/Ic.cpp
@@ -727,7 +727,7 @@ void Ic<ndim>::AddHexagonalLattice
   if (ndim == 1) {
     for (ii=0; ii<Nlattice[0]; ii++) {
       i = ii;
-      r[i] = box.min[0] + (FLOAT) 0.5*rad[0] + (FLOAT) 2.0*(FLOAT)ii*rad[0];
+      r[ndim*i] = box.min[0] + rad[0] + (FLOAT) 2.0*(FLOAT) ii*rad[0];
     }
   }
 
@@ -737,7 +737,7 @@ void Ic<ndim>::AddHexagonalLattice
       for (ii=0; ii<Nlattice[0]; ii++) {
         i = jj*Nlattice[0] + ii;
         r[ndim*i] = box.min[0] +
-          (FLOAT) 0.5*rad[0] + ((FLOAT) 2.0*(FLOAT)ii + (FLOAT)(jj%2))*rad[0];
+          rad[0] + ((FLOAT) 2.0*(FLOAT)ii + (FLOAT)(jj%2))*rad[0];
         r[ndim*i + 1] = box.min[1] +
           (FLOAT) 0.5*sqrt((FLOAT) 3.0)*rad[1] + (FLOAT)jj*sqrt(3.0)*rad[1];
       }
@@ -751,7 +751,7 @@ void Ic<ndim>::AddHexagonalLattice
       for (jj=0; jj<Nlattice[1]; jj++) {
         for (ii=0; ii<Nlattice[0]; ii++) {
           i = kk*Nlattice[0]*Nlattice[1] + jj*Nlattice[0] + ii;
-          r[ndim*i] = box.min[0] + (FLOAT) 0.5*rad[0] +
+          r[ndim*i] = box.min[0] + rad[0] +
             ((FLOAT) 2.0*(FLOAT) ii + (FLOAT) (jj%2) + (FLOAT) ((kk+1)%2))*rad[0];
           r[ndim*i + 1] = box.min[1] + (FLOAT) 0.5*sqrt((FLOAT) 3.0)*rad[1] +
             (FLOAT) jj*sqrt((FLOAT) 3.0)*rad[1] + (FLOAT) (kk%2)*rad[1]/sqrt((FLOAT) 3.0);

--- a/src/Ic/PolytropeIc.cpp
+++ b/src/Ic/PolytropeIc.cpp
@@ -134,35 +134,6 @@ void PolytropeIc<ndim>::Generate(void)
 
 
 //=================================================================================================
-//  PolytropeIc::GetValue
-/// ...
-//=================================================================================================
-template <int ndim>
-FLOAT PolytropeIc<ndim>::GetValue
- (const std::string var,
-  const FLOAT r[ndim])
-{
-  if (var == "x") {
-    return r[0];
-  }
-  else if (ndim > 1 && var == "y") {
-    return r[1];
-  }
-  else if (ndim > 2 && var == "z") {
-    return r[2];
-  }
-  else if (var == "rho") {
-    return (FLOAT) 0.0;
-  }
-  else {
-    std::cout << "Invalid string variable for PolytropeIc::GetValue" << std::endl;
-    return 0.0;
-  }
-}
-
-
-
-//=================================================================================================
 //  PolytropeIc::ComputeIsothermalLaneEmdenEquation
 /// Create initial conditions for binary accretion simulation.
 //=================================================================================================

--- a/src/Ic/SoundwaveIc.cpp
+++ b/src/Ic/SoundwaveIc.cpp
@@ -38,10 +38,6 @@ template <int ndim>
 SoundwaveIc<ndim>::SoundwaveIc(Simulation<ndim>* _sim, FLOAT _invndim) :
   Ic<ndim>(_sim, _invndim)
 {
-  // Some sanity checking to ensure dimensionless units are used
-  if (simparams->intparams["ndim"] != 1) {
-    ExceptionHandler::getIstance().raise("Soundwave sim only runs in 1D");
-  }
   if (simparams->intparams["dimensionless"] == 0) {
     ExceptionHandler::getIstance().raise("dimensionless units required");
   }
@@ -56,94 +52,129 @@ SoundwaveIc<ndim>::SoundwaveIc(Simulation<ndim>* _sim, FLOAT _invndim) :
 template <int ndim>
 void SoundwaveIc<ndim>::Generate(void)
 {
+  int i,k;                          // Particle and dimension counters
+  int Nlattice[ndim];              // Lattice size
+  FLOAT csound;                     // (Isothermal) sound speed
+  FLOAT lambda;                     // Wavelength of perturbation
+  FLOAT kwave;                      // Wave number of perturbing sound wave
+  //FLOAT omegawave;                  // Angular frequency of sound wave
+  FLOAT ugas;                       // Internal energy of gas
+  FLOAT volume;
+  FLOAT *r;                         // Particle positions
+
+  // Make local copies of parameters for setting up problem
+  int Npart       = simparams->intparams["Nhydro"];
+  FLOAT rhofluid1 = simparams->floatparams["rhofluid1"];
+  FLOAT press1    = simparams->floatparams["press1"];
+  FLOAT gamma     = simparams->floatparams["gamma_eos"];
+  FLOAT gammaone  = gamma - (FLOAT) 1.0;
+  FLOAT amp       = simparams->floatparams["amp"];
+  FLOAT temp0     = simparams->floatparams["temp0"];
+  FLOAT mu_bar    = simparams->floatparams["mu_bar"];
+  std::string particle_dist = simparams->stringparams["particle_distribution"];
+  //Nlattice1[0]    = simparams->intparams["Nlattice1[0]"];
+
+  debug2("[SoundwaveIc::Generate]");
+
+  if (hydro->gas_eos == "isothermal") {
+    ugas   = temp0/gammaone/mu_bar;
+    press1 = gammaone*rhofluid1*ugas;
+    csound = sqrt(press1/rhofluid1);
+  }
+  else {
+    ugas   = press1/rhofluid1/gammaone;
+    csound = sqrt(gamma*press1/rhofluid1);
+  }
+
+  lambda = icBox.max[0] - icBox.min[0];
+  kwave = twopi/lambda;
+  //omegawave = twopi*csound/lambda;
+
+  // Allocate local and main particle memory
+  //for (k=0; k<ndim; k++) Nlattice1[k] = 1;
+  Nlattice[0]    = simparams->intparams["Nlattice1[0]"];
+  Nlattice[1]    = simparams->intparams["Nlattice1[1]"];
+  Nlattice[2]    = simparams->intparams["Nlattice1[2]"];
+  //Nlattice1[0] = Npart;
+
   if (ndim == 1) {
+    volume = icBox.max[0] - icBox.min[0];
+    Npart = Nlattice[0];
+  }
+  else if (ndim == 2) {
+    volume = (icBox.max[0] - icBox.min[0])*(icBox.max[1] - icBox.min[1]);
+    Npart = Nlattice[0]*Nlattice[1];
+  }
+  else if (ndim == 3) {
+    volume = (icBox.max[0] - icBox.min[0])*
+      (icBox.max[1] - icBox.min[1])*(icBox.max[2] - icBox.min[2]);
+    Npart = Nlattice[0]*Nlattice[1]*Nlattice[2];
+  }
 
-    int i,k;                          // Particle and dimension counters
-    int Nlattice1[ndim];              // Lattice size
-    FLOAT csound;                     // (Isothermal) sound speed
-    FLOAT lambda;                     // Wavelength of perturbation
-    FLOAT kwave;                      // Wave number of perturbing sound wave
-    //FLOAT omegawave;                  // Angular frequency of sound wave
-    FLOAT ugas;                       // Internal energy of gas
-    FLOAT *r;                         // Particle positions
+  hydro->Nhydro = Npart;
+  bool dusty_wave = simparams->stringparams["dust_forces"] != "none" ;
+  if (dusty_wave) hydro->Nhydro *= 2;
 
-    // Make local copies of parameters for setting up problem
-    int Npart       = simparams->intparams["Nhydro"];
-    FLOAT rhofluid1 = simparams->floatparams["rhofluid1"];
-    FLOAT press1    = simparams->floatparams["press1"];
-    FLOAT gamma     = simparams->floatparams["gamma_eos"];
-    FLOAT gammaone  = gamma - (FLOAT) 1.0;
-    FLOAT amp       = simparams->floatparams["amp"];
-    FLOAT temp0     = simparams->floatparams["temp0"];
-    FLOAT mu_bar    = simparams->floatparams["mu_bar"];
-    //Nlattice1[0]    = simparams->intparams["Nlattice1[0]"];
+  sim->AllocateParticleMemory();
+  r = new FLOAT[ndim*Npart];
 
-    debug2("[SoundwaveIc::Generate]");
+  // Add a cube of random particles defined by the simulation bounding box and
+  // depending on the chosen particle distribution
+  if (particle_dist == "random") {
+    Ic<ndim>::AddRandomBox(Npart, icBox, r, sim->randnumb);
+  }
+  else if (particle_dist == "cubic_lattice") {
+    Ic<ndim>::AddCubicLattice(Npart, Nlattice, icBox, true, r);
+  }
+  else if (particle_dist == "hexagonal_lattice") {
+    Ic<ndim>::AddHexagonalLattice(Npart, Nlattice, icBox, true, r);
+  }
+  else {
+    string message = "Invalid particle distribution option";
+    ExceptionHandler::getIstance().raise(message);
+  }
 
-    if (hydro->gas_eos == "isothermal") {
-      ugas   = temp0/gammaone/mu_bar;
-      press1 = gammaone*rhofluid1*ugas;
-      csound = sqrt(press1/rhofluid1);
+  // Add sinusoidal density perturbation to particle distribution
+  Ic<ndim>::AddSinusoidalDensityPerturbation(Npart, amp, lambda, r);
+
+
+  // Set all other particle quantities
+  //----------------------------------------------------------------------------------------------
+  for (i=0; i<Npart; i++) {
+    Particle<ndim>& part = hydro->GetParticlePointer(i);
+
+    // Set positions in main array with corresponind velocity perturbation
+    for (k=0; k<ndim; k++) part.r[k] = r[ndim*i + k];
+    for (k=0; k<ndim; k++) part.v[k] = 0.0;
+    part.v[0] = csound*amp*sin(kwave*r[ndim*i]);
+    part.m = rhofluid1*volume/(FLOAT) Npart;
+    part.h = hydro->h_fac*pow(part.m/rhofluid1,invndim);
+    part.u = ugas; //*((FLOAT) 1.0 + amp*sin(kwave*r[ndim*i]));
+    part.rho = rhofluid1*(1.0 + amp*sin(twopi*part.r[0]/lambda));
+#ifdef GADGET_SPH
+    part.Aent = gammaone*part.u*pow(part.rho,(FLOAT) 1.0 - gamma);
+#endif
+
+  }
+  //-----------------------------------------------------------------------------------------------
+
+  if (dusty_wave){
+    FLOAT d2g = simparams->floatparams["dust_mass_factor"] ;
+    for (i = 0; i < Npart; ++i) {
+      Particle<ndim>& Pg = hydro->GetParticlePointer(i) ;
+      Particle<ndim>& Pd = hydro->GetParticlePointer(i+Npart) ;
+      Pd = Pg ;
+      Pd.m *= d2g ;
+      Pd.h_dust = Pd.h ;
+      Pd.u = 0 ;
+
+      Pg.ptype = gas_type ;
+      Pd.ptype = dust_type ;
     }
-    else {
-      ugas   = press1/rhofluid1/gammaone;
-      csound = sqrt(gamma*press1/rhofluid1);
-    }
 
-    lambda = icBox.max[0] - icBox.min[0];
-    kwave = twopi/lambda;
-    //omegawave = twopi*csound/lambda;
+    sim->initial_h_provided = true;
+    delete[] r;
 
-    // Allocate local and main particle memory
-    for (k=0; k<ndim; k++) Nlattice1[k] = 1;
-    Nlattice1[0] = Npart;
-
-    hydro->Nhydro = Npart;
-    bool dusty_wave = simparams->stringparams["dust_forces"] != "none" ;
-    if (dusty_wave) hydro->Nhydro *= 2;
-
-    sim->AllocateParticleMemory();
-    r = new FLOAT[ndim*Npart];
-
-    // Add regular distribution of SPH particles
-    Ic<ndim>::AddCubicLattice(Npart, Nlattice1, icBox, false, r);
-
-    // Add sinusoidal density perturbation to particle distribution
-    Ic<ndim>::AddSinusoidalDensityPerturbation(Npart, amp, lambda, r);
-
-    // Set all other particle quantities
-    //----------------------------------------------------------------------------------------------
-    for (i=0; i<Npart; i++) {
-      Particle<ndim>& part = hydro->GetParticlePointer(i);
-
-      // Set positions in main array with corresponind velocity perturbation
-      for (k=0; k<ndim; k++) part.r[k] = r[ndim*i];
-      for (k=0; k<ndim; k++) part.v[k] = csound*amp*sin(kwave*r[ndim*i]);
-      part.m = rhofluid1*lambda/(FLOAT) Npart;
-      part.h = hydro->h_fac*pow(part.m/rhofluid1,invndim);
-      part.u = ugas; //*((FLOAT) 1.0 + amp*sin(kwave*r[ndim*i]));
-
-    }
-    //-----------------------------------------------------------------------------------------------
-
-    if (dusty_wave){
-      FLOAT d2g = simparams->floatparams["dust_mass_factor"] ;
-      for (i = 0; i < Npart; ++i) {
-        Particle<ndim>& Pg = hydro->GetParticlePointer(i) ;
-        Particle<ndim>& Pd = hydro->GetParticlePointer(i+Npart) ;
-        Pd = Pg ;
-        Pd.m *= d2g ;
-        Pd.h_dust = Pd.h ;
-        Pd.u = 0 ;
-
-        Pg.ptype = gas_type ;
-        Pd.ptype = dust_type ;
-      }
-
-      sim->initial_h_provided = true;
-      delete[] r;
-
-    }
   }
 
   return;

--- a/tests/hydro_tests/cdiscontinuity.dat
+++ b/tests/hydro_tests/cdiscontinuity.dat
@@ -6,27 +6,27 @@
 #-----------------------------
 # Initial conditions variables
 #-----------------------------
-Simulation run id string                    : run_id = CDISC1
-Select SPH simulation                       : sim = sph
+Simulation run id string                    : run_id = DISCONTINUITY-2D-MFV
+Select SPH simulation                       : sim = mfvmuscl
 Select Kelvin-Helmholtz initial conditions  : ic = cdiscontinuity
-1D shocktube test                           : ndim = 1
+1D shocktube test                           : ndim = 2
 x-velocity of LHS fluid                     : vfluid1[0] = 0.0
 x-velocity of RHS fluid                     : vfluid2[0] = 0.0
-Pressure of LHS fluid                       : press1 = 10.0
-Pressure of RHS fluid                       : press2 = 10.0
-Density of LHS fluid                        : rhofluid1 = 1.0
-Density of RHS fluid                        : rhofluid2 = 10.0
-No. of particles in LHS fluid               : Nlattice1[0] = 240
-No. of particles in RHS fluid               : Nlattice2[0] = 600
+Pressure of LHS fluid                       : press1 = 3.75
+Density of LHS fluid                        : rhofluid1 = 1.75
+Density of RHS fluid                        : rhofluid2 = 4.0
+No. of particles in LHS fluid               : Nlattice1[0] = 128
+No. of particles in RHS fluid               : Nlattice1[1] = 128
+Dimensionless units                         : dimensionless = 1
 
 
 #------------------------------
 # Simulation boundary variables
 #------------------------------
-LHS position of boundary in x-dimension     : boxmin[0] = 0.0
-RHS position of boundary in x-dimension     : boxmax[0] = 1.0
-LHS position of boundary in y-dimension     : boxmin[1] = 0.0
-RHS position of boundary in y-dimension     : boxmax[1] = 1.0
+LHS position of boundary in x-dimension     : boxmin[0] = -0.5
+RHS position of boundary in x-dimension     : boxmax[0] = 0.5
+LHS position of boundary in y-dimension     : boxmin[1] = -0.5
+RHS position of boundary in y-dimension     : boxmax[1] = 0.5
 LHS boundary type in x-dimension            : boundary_lhs[0] = periodic
 RHS boundary type in x-dimension            : boundary_rhs[0] = periodic
 LHS boundary type in y-dimension            : boundary_lhs[1] = periodic
@@ -36,9 +36,10 @@ RHS boundary type in y-dimension            : boundary_rhs[1] = periodic
 #--------------------------
 # Simulation time variables
 #--------------------------
-Simulation end time                         : tend = 20.0
-Regular snapshot output frequency           : dt_snap = 1.0
+Simulation end time                         : tend = 3.0
+Regular snapshot output frequency           : dt_snap = 0.2
 Screen output frequency (in no. of steps)   : noutputstep = 128
+Output snapshot format                      : out_file_form = su
 
 
 #------------------------
@@ -52,7 +53,6 @@ Ratio of specific heats of gas              : gamma_eos = 1.66666666666666
 #----------------------------------------
 # Smoothed Particle Hydrodynamics options
 #----------------------------------------
-SPH algorithm choice                        : sph = sm2012
 SPH smoothing kernel choice                 : kernel = quintic
 SPH smoothing length iteration tolerance    : h_converge = 0.01
 
@@ -62,8 +62,10 @@ SPH smoothing length iteration tolerance    : h_converge = 0.01
 #---------------------------------
 Artificial viscosity choice                 : avisc = mon97
 Artificial conductivity choice              : acond = none
-Artificial viscosity alpha value            : alpha_visc = 1.0
-Artificial viscosity beta value             : beta_visc = 2.0
+Artificial viscosity alpha value            : alpha_visc = 0.1
+Artificial viscosity beta value             : beta_visc = 0.2
+Riemann solver                              : riemann_solver = exact
+Slope limiter                               : slope_limiter = gizmo
 
 
 #-------------------------
@@ -76,10 +78,12 @@ SPH energy equation timestep multiplier     : energy_mult = 0.5
 No. of block timestep levels                : Nlevels = 1
 
 
-#--------------------
+#-------------
 # Tree options
-#--------------------
+#-------------
 SPH neighbour search algorithm              : neib_search = kdtree
+No. of particles in leaf cell               : Nleafmax = 12
+Tree stock frequency                        : ntreestockstep = 1
 
 
 #--------------

--- a/tests/hydro_tests/soundwave.dat
+++ b/tests/hydro_tests/soundwave.dat
@@ -9,15 +9,16 @@
 # Initial conditions variables
 #-----------------------------
 Simulation run id string                    : run_id = SOUNDWAVE1
-Select SPH simulation                       : sim = sph
+Select SPH simulation                       : sim = gradhsph
 Select shocktube initial conditions         : ic = soundwave
 1D shocktube test                           : ndim = 1
 Pressure of LHS fluid                       : press1 = 1.0
 Density of LHS fluid                        : rhofluid1 = 1.0
 Sound wave amplitude                        : amp = 0.001
+No. of particles in wave (used in 1D test)  : Nhydro = 256
 No. of x-particles in fluid 1               : Nlattice1[0] = 32
 No. of y-particles in fluid 1               : Nlattice1[1] = 32
-No. of y-particles in fluid 1               : Nlattice1[2] = 32
+No. of z-particles in fluid 1               : Nlattice1[2] = 32
 Local arrangement of particles              : particle_distribution = hexagonal_lattice
 Use dimensionless units                     : dimensionless = 1
 com_frame = 0
@@ -74,7 +75,6 @@ Artificial conductivity choice              : acond = none
 Artificial viscosity alpha value            : alpha_visc = 0.001
 Artificial viscosity beta value             : beta_visc = 0.002
 Riemann solver                              : riemann_solver = exact
-Order of Riemann solver                     : riemann_order = 2
 Slope limiter                               : slope_limiter = gizmo
 
 

--- a/tests/hydro_tests/soundwave.dat
+++ b/tests/hydro_tests/soundwave.dat
@@ -19,7 +19,7 @@ No. of particles in wave (used in 1D test)  : Nhydro = 256
 No. of x-particles in fluid 1               : Nlattice1[0] = 32
 No. of y-particles in fluid 1               : Nlattice1[1] = 32
 No. of z-particles in fluid 1               : Nlattice1[2] = 32
-Local arrangement of particles              : particle_distribution = hexagonal_lattice
+Local arrangement of particles              : particle_distribution = cubic_lattice
 Use dimensionless units                     : dimensionless = 1
 com_frame = 0
 
@@ -27,8 +27,8 @@ com_frame = 0
 #------------------------------
 # Simulation boundary variables
 #------------------------------
-LHS position of boundary in x-dimension     : boxmin[0] = -0.5
-RHS position of boundary in x-dimension     : boxmax[0] = 0.5
+LHS position of boundary in x-dimension     : boxmin[0] = 0.0
+RHS position of boundary in x-dimension     : boxmax[0] = 1.0
 LHS position of boundary in y-dimension     : boxmin[1] = -0.433
 RHS position of boundary in y-dimension     : boxmax[1] = 0.433
 LHS position of boundary in z-dimension     : boxmin[2] = -0.4082

--- a/tests/hydro_tests/soundwave.dat
+++ b/tests/hydro_tests/soundwave.dat
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------
 # Sound wave test
-# Generates and propagates a small linear density perturbation as a 
+# Generates and propagates a small linear density perturbation as a
 # sound-wave along a uniform density gas.
 #------------------------------------------------------------------
 
@@ -15,17 +15,30 @@ Select shocktube initial conditions         : ic = soundwave
 Pressure of LHS fluid                       : press1 = 1.0
 Density of LHS fluid                        : rhofluid1 = 1.0
 Sound wave amplitude                        : amp = 0.001
-No. of particles in wave                    : Nhydro = 256
+No. of x-particles in fluid 1               : Nlattice1[0] = 32
+No. of y-particles in fluid 1               : Nlattice1[1] = 32
+No. of y-particles in fluid 1               : Nlattice1[2] = 32
+Local arrangement of particles              : particle_distribution = hexagonal_lattice
 Use dimensionless units                     : dimensionless = 1
+com_frame = 0
 
 
 #------------------------------
 # Simulation boundary variables
 #------------------------------
-LHS position of boundary in x-dimension     : boxmin[0] = 0.0
-RHS position of boundary in x-dimension     : boxmax[0] = 1.0
+LHS position of boundary in x-dimension     : boxmin[0] = -0.5
+RHS position of boundary in x-dimension     : boxmax[0] = 0.5
+LHS position of boundary in y-dimension     : boxmin[1] = -0.433
+RHS position of boundary in y-dimension     : boxmax[1] = 0.433
+LHS position of boundary in z-dimension     : boxmin[2] = -0.4082
+RHS position of boundary in z-dimension     : boxmax[2] = 0.4082
 LHS boundary type in x-dimension            : boundary_lhs[0] = periodic
 RHS boundary type in x-dimension            : boundary_rhs[0] = periodic
+LHS boundary type in y-dimension            : boundary_lhs[1] = periodic
+RHS boundary type in y-dimension            : boundary_rhs[1] = periodic
+LHS boundary type in z-dimension            : boundary_lhs[2] = periodic
+RHS boundary type in z-dimension            : boundary_rhs[2] = periodic
+
 
 
 #--------------------------
@@ -41,7 +54,7 @@ Screen output frequency (in no. of steps)   : noutputstep = 1024
 # Thermal physics options
 #------------------------
 Switch-on hydrodynamical forces             : hydro_forces = 1
-Main gas thermal physics treatment          : gas_eos = isothermal
+Main gas thermal physics treatment          : gas_eos = energy_eqn
 Ratio of specific heats of gas              : gamma_eos = 1.66666666666666666
 
 
@@ -49,7 +62,7 @@ Ratio of specific heats of gas              : gamma_eos = 1.66666666666666666
 # Smoothed Particle Hydrodynamics options
 #----------------------------------------
 SPH algorithm choice                        : sph = gradh
-SPH smoothing kernel choice                 : kernel = gaussian
+SPH smoothing kernel choice                 : kernel = m4
 SPH smoothing length iteration tolerance    : h_converge = 0.000000001
 
 
@@ -58,8 +71,8 @@ SPH smoothing length iteration tolerance    : h_converge = 0.000000001
 #---------------------------------
 Artificial viscosity choice                 : avisc = none
 Artificial conductivity choice              : acond = none
-Artificial viscosity alpha value            : alpha_visc = 0.01
-Artificial viscosity beta value             : beta_visc = 0.02
+Artificial viscosity alpha value            : alpha_visc = 0.001
+Artificial viscosity beta value             : beta_visc = 0.002
 Riemann solver                              : riemann_solver = exact
 Order of Riemann solver                     : riemann_order = 2
 Slope limiter                               : slope_limiter = gizmo
@@ -69,8 +82,8 @@ Slope limiter                               : slope_limiter = gizmo
 # Time integration options
 #-------------------------
 SPH particle integration option             : sph_integration = lfkdk
-SPH Courant timestep condition multiplier   : courant_mult = 0.025
-SPH acceleration condition multiplier       : accel_mult = 0.05
+SPH Courant timestep condition multiplier   : courant_mult = 0.1
+SPH acceleration condition multiplier       : accel_mult = 0.1
 No. of block timestep levels                : Nlevels = 1
 
 


### PR DESCRIPTION
Following improvements/fixes already added : 
- Changed Soundwave test to allow 2d or 3d tests
- Changed discontinuity test to generate ICs similar to Hopkins (2013) square pressure-discontinuity test
- Removed any remaining GetValue calls (now using GetDensity for regularisation)

A few possible changes to come before this should be merged
- Clean-up parameters files to remove old/un-unused parameters (e.g. riemann_order, sph)
- Improve/clean-up some comments (plenty of copy-and-pasting that was not corrected)
- Add GetDensity and SetProperties function to some other IC classes to allow regularisation to be used (Giovanni, Richard : could the DiscIc class be changed to use the regularisation?  It starts off with random sampling which could instead be done by the other functions in the IC class and then regularisation could 'clean-up' the noise)

Any other suggested IC class improvements that could go with this pull request (but nothing too big obviously)?